### PR TITLE
Update Dockerfile to golang 1.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine
+FROM golang:1.19-alpine
 RUN mkdir /app
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
To avoid this error
```
go: downloading github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec
# go.mau.fi/whatsmeow/store/sqlstore
/go/pkg/mod/go.mau.fi/whatsmeow@v0.0.0-20230621213630-12cd3cdb2257/store/sqlstore/store.go:752:17: undefined: any
note: module requires Go 1.19
```
