### PR TITLE
Update Dockerfile to optimize image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
-FROM golang:1.19-alpine
+FROM golang:1.21-alpine AS build
 RUN mkdir /app
 COPY . /app
 WORKDIR /app
 RUN go build -o server .
+
+FROM alpine:latest
+RUN mkdir /app
+COPY ./static /app/static
+COPY --from=build /app/server /app/
 VOLUME [ "/app/dbdata", "/app/files" ]
-ENTRYPOINT [ "/app/server" ]
-CMD [ "-logtype", "json" ]
+WORKDIR /app
+CMD [ "/app/server", "-logtype", "json" ]


### PR DESCRIPTION
## Pull Request Summary:

### Changes Made

- Updated the Dockerfile to optimize the resulting Docker image size.
- Previously: 983MB, New Size: 40.1MB.
- The new image now contains only the result binary and its supporting files, excluding build dependencies.
- Changed the execution in the Dockerfile, use CMD instead of the ENTRYPOINT.

### Reason for Changes

The primary goal of this update is to significantly reduce the image size by excluding unnecessary build dependencies. Additionally, the change in CMD improves the usability of the Docker image, allowing users to enter the container interactively.

### Impact
- Before: 983MB
- After: 40.1MB

### Testing

- [x] Verified that the updated Docker image successfully builds and runs.
- [x] Checked that the application functions as expected within the reduced image.
- [x] Confirmed that entering the container interactively using `docker run --rm -it wuzapi-image /bin/sh` works as expected.

### Additional Notes

- This update should not affect the functionality of the application but significantly improves the image size, making it more suitable for deployment and distribution.
- Users can now enter the container interactively using the provided docker run command.