### PR TITLE
Corrección Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM golang:1.21-alpine AS build
+RUN apk add --no-cache gcc musl-dev
 RUN mkdir /app
 COPY . /app
 WORKDIR /app
 RUN go mod tidy
+ENV CGO_ENABLED=1
 RUN go build -o server .
 
 FROM alpine:latest


### PR DESCRIPTION
Esta modificación en el Dockerfile me permitió solucionar un error que se producía al iniciar el contenedor, el error que tenía en el contenedor era:

_panic: failed to upgrade database: Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work. This is a stub
goroutine 1 [running]:
main.main()
	/app/main.go:101 +0x764_

Espero que pueda ayudar a alguien más. :)
