### PR TITLE
feat(docker): add RabbitMQ configuration to Docker Compose files

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -19,3 +19,7 @@ WUZAPI_GLOBAL_WEBHOOK=https://example.com/webhook
 
 # "json" or "form" for the default
 WEBHOOK_FORMAT=json
+
+# RabbitMQ configuration Optional
+RABBITMQ_URL=amqp://wuzapi:wuzapi@localhost:5672/
+RABBITMQ_QUEUE=whatsapp_events

--- a/docker-compose-swarm.yaml
+++ b/docker-compose-swarm.yaml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: "3.7"
 
 services:
   wuzapi-server:
@@ -15,6 +15,9 @@ services:
       - TZ=America/Sao_Paulo
       - WEBHOOK_FORMAT=json
       - SESSION_DEVICE_NAME=WuzAPI
+      # RabbitMQ configuration Optional
+      - RABBITMQ_URL=amqp://wuzapi:wuzapi@rabbitmq:5672/
+      - RABBITMQ_QUEUE=whatsapp_events
     deploy:
       mode: replicated
       replicas: 1
@@ -40,6 +43,40 @@ services:
     #   timeout: 5s
     #   retries: 3
     #   start_period: 10s
+
+  # RabbitMQ service OPTIONAL
+  rabbitmq:
+    image: rabbitmq:3-management
+    networks:
+      - network_public
+    environment:
+      - RABBITMQ_DEFAULT_USER=wuzapi
+      - RABBITMQ_DEFAULT_PASS=wuzapi
+      - RABBITMQ_DEFAULT_VHOST=/
+    deploy:
+      mode: replicated
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+      placement:
+        constraints: [node.role == manager]
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 256MB
+      labels:
+        - traefik.enable=true
+        - traefik.http.routers.rabbitmq-management.rule=Host(`rabbitmq.wuzapi.app`)
+        - traefik.http.routers.rabbitmq-management.entrypoints=websecure
+        - traefik.http.routers.rabbitmq-management.priority=1
+        - traefik.http.routers.rabbitmq-management.tls.certresolver=letsencryptresolver
+        - traefik.http.routers.rabbitmq-management.service=rabbitmq-management
+        - traefik.http.services.rabbitmq-management.loadbalancer.server.port=15672
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+
+volumes:
+  rabbitmq_data:
 
 networks:
   network_public:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,13 @@ services:
       - TZ=America/Sao_Paulo
       - WEBHOOK_FORMAT=json
       - SESSION_DEVICE_NAME=WuzAPI
+      # RabbitMQ configuration Optional
+      - RABBITMQ_URL=amqp://wuzapi:wuzapi@rabbitmq:5672/
+      - RABBITMQ_QUEUE=whatsapp_events
     depends_on:
       db:
+        condition: service_healthy
+      rabbitmq:
         condition: service_healthy
     networks:
       - wuzapi-network
@@ -40,10 +45,31 @@ services:
       timeout: 5s
       retries: 5
     restart: always
-      
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    environment:
+      RABBITMQ_DEFAULT_USER: wuzapi
+      RABBITMQ_DEFAULT_PASS: wuzapi
+      RABBITMQ_DEFAULT_VHOST: /
+    ports:
+      - "5672:5672" # AMQP port
+      - "15672:15672" # Management UI port
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+    networks:
+      - wuzapi-network
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: always
+
 networks:
   wuzapi-network:
     driver: bridge
 
 volumes:
   db_data:
+  rabbitmq_data:


### PR DESCRIPTION
This pull request adds and documents the optional variables for WuzAPI integration with RabbitMQ in the example .env, docker-compose stadalone and swarm.

**RabbitMQ Integration:**

* Added RabbitMQ configuration variables (`RABBITMQ_URL` and `RABBITMQ_QUEUE`) to `.env.sample` for optional use.
* Updated both `docker-compose.yml` and `docker-compose-swarm.yaml` to include RabbitMQ service definitions, with appropriate environment variables, volumes, health checks, and network settings. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R49-R75) [[2]](diffhunk://#diff-870aa9027bbbe88152cd1e2498b02a1b1f17ab25880c82ea9d34d92f1c0dc424R47-R80)
* Injected RabbitMQ-related environment variables into the `wuzapi-server` service in both compose files, allowing the application to connect to RabbitMQ if configured. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R18-R25) [[2]](diffhunk://#diff-870aa9027bbbe88152cd1e2498b02a1b1f17ab25880c82ea9d34d92f1c0dc424R18-R20)
* Ensured that the `wuzapi-server` service waits for RabbitMQ to be healthy before starting, improving startup reliability in development.