### PR TITLE
Implement history logging in wuzapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ you can use to alter behaviour
 * -osname : Connection OS Name in Whatsapp
 * -skipmedia : Skip downloading media from messages
 * -wadebug : enable whatsmeow debug, either INFO or DEBUG levels are suported
+
 * -sslcertificate : SSL Certificate File
 * -sslprivatekey : SSL Private Key File
 

--- a/db.go
+++ b/db.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
@@ -97,4 +98,59 @@ func initializeSQLite(config DatabaseConfig) (*sqlx.DB, error) {
 	}
 
 	return db, nil
+}
+
+type HistoryMessage struct {
+	ID          int       `json:"id" db:"id"`
+	UserID      string    `json:"user_id" db:"user_id"`
+	ChatJID     string    `json:"chat_jid" db:"chat_jid"`
+	SenderJID   string    `json:"sender_jid" db:"sender_jid"`
+	MessageID   string    `json:"message_id" db:"message_id"`
+	Timestamp   time.Time `json:"timestamp" db:"timestamp"`
+	MessageType string    `json:"message_type" db:"message_type"`
+	TextContent string    `json:"text_content" db:"text_content"`
+	MediaLink   string    `json:"media_link" db:"media_link"`
+}
+
+func (s *server) saveMessageToHistory(userID, chatJID, senderJID, messageID, messageType, textContent, mediaLink string) error {
+	query := `INSERT INTO message_history (user_id, chat_jid, sender_jid, message_id, timestamp, message_type, text_content, media_link)
+              VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
+	if s.db.DriverName() == "sqlite" {
+		query = `INSERT INTO message_history (user_id, chat_jid, sender_jid, message_id, timestamp, message_type, text_content, media_link)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+	}
+	_, err := s.db.Exec(query, userID, chatJID, senderJID, messageID, time.Now(), messageType, textContent, mediaLink)
+	if err != nil {
+		return fmt.Errorf("failed to save message to history: %w", err)
+	}
+	return nil
+}
+
+func (s *server) trimMessageHistory(userID, chatJID string, limit int) error {
+	var query string
+	if s.db.DriverName() == "postgres" {
+		query = `
+            DELETE FROM message_history
+            WHERE id IN (
+                SELECT id FROM message_history
+                WHERE user_id = $1 AND chat_jid = $2
+                ORDER BY timestamp DESC
+                OFFSET $3
+            )`
+	} else { // sqlite
+		query = `
+            DELETE FROM message_history
+            WHERE id IN (
+                SELECT id FROM message_history
+                WHERE user_id = ? AND chat_jid = ?
+                ORDER BY timestamp DESC
+                LIMIT -1 OFFSET ?
+            )`
+	}
+
+	_, err := s.db.Exec(query, userID, chatJID, limit)
+	if err != nil {
+		return fmt.Errorf("failed to trim message history: %w", err)
+	}
+	return nil
 }

--- a/handlers.go
+++ b/handlers.go
@@ -93,7 +93,7 @@ func (s *server) authalice(next http.Handler) http.Handler {
 				}
 				
 				// Debug logging for history value
-				log.Info().Str("userId", txtid).Bool("historyValid", history.Valid).Int64("historyValue", history.Int64).Str("historyStr", historyStr).Msg("User authentication - history debug")
+log.Debug().Str("userId", txtid).Bool("historyValid", history.Valid).Int64("historyValue", history.Int64).Str("historyStr", historyStr).Msg("User authentication - history debug")
 				
 				v := Values{map[string]string{
 					"Id":      txtid,

--- a/main.go
+++ b/main.go
@@ -34,18 +34,18 @@ type server struct {
 
 // Replace the global variables
 var (
-	address       = flag.String("address", "0.0.0.0", "Bind IP Address")
-	port          = flag.String("port", "8080", "Listen Port")
-	waDebug       = flag.String("wadebug", "", "Enable whatsmeow debug (INFO or DEBUG)")
-	logType       = flag.String("logtype", "console", "Type of log output (console or json)")
-	skipMedia     = flag.Bool("skipmedia", false, "Do not attempt to download media in messages")
-	osName        = flag.String("osname", "Mac OS 10", "Connection OSName in Whatsapp")
-	colorOutput   = flag.Bool("color", false, "Enable colored output for console logs")
-	sslcert       = flag.String("sslcertificate", "", "SSL Certificate File")
-	sslprivkey    = flag.String("sslprivatekey", "", "SSL Certificate Private Key File")
-	adminToken    = flag.String("admintoken", "", "Security Token to authorize admin actions (list/create/remove users)")
-	globalWebhook = flag.String("globalwebhook", "", "Global webhook URL to receive all events from all users")
-	versionFlag   = flag.Bool("version", false, "Display version information and exit")
+	address         = flag.String("address", "0.0.0.0", "Bind IP Address")
+	port            = flag.String("port", "8080", "Listen Port")
+	waDebug         = flag.String("wadebug", "", "Enable whatsmeow debug (INFO or DEBUG)")
+	logType         = flag.String("logtype", "console", "Type of log output (console or json)")
+	skipMedia       = flag.Bool("skipmedia", false, "Do not attempt to download media in messages")
+	osName          = flag.String("osname", "Mac OS 10", "Connection OSName in Whatsapp")
+	colorOutput     = flag.Bool("color", false, "Enable colored output for console logs")
+	sslcert         = flag.String("sslcertificate", "", "SSL Certificate File")
+	sslprivkey      = flag.String("sslprivatekey", "", "SSL Certificate Private Key File")
+	adminToken      = flag.String("admintoken", "", "Security Token to authorize admin actions (list/create/remove users)")
+	globalWebhook   = flag.String("globalwebhook", "", "Global webhook URL to receive all events from all users")
+	versionFlag     = flag.Bool("version", false, "Display version information and exit")
 
 	container        *sqlstore.Container
 	clientManager    = NewClientManager()

--- a/routes.go
+++ b/routes.go
@@ -106,6 +106,7 @@ func (s *server) routes() {
 	s.router.Handle("/chat/send/list", c.Then(s.SendList())).Methods("POST")
 	s.router.Handle("/chat/send/poll", c.Then(s.SendPoll())).Methods("POST")
 	s.router.Handle("/chat/send/edit", c.Then(s.SendEditMessage())).Methods("POST")
+	s.router.Handle("/chat/history", c.Then(s.GetHistory())).Methods("GET")
 
 	s.router.Handle("/user/presence", c.Then(s.SendPresence())).Methods("POST")
 	s.router.Handle("/user/info", c.Then(s.GetUser())).Methods("POST")

--- a/static/api/spec.yml
+++ b/static/api/spec.yml
@@ -69,6 +69,7 @@ paths:
                     public_url: "https://s3.amazonaws.com"
                     media_delivery: "both"
                     retention_days: 30
+                  history: 0
   /admin/users/{id}:
     delete:
       tags:
@@ -1057,6 +1058,90 @@ paths:
             application/json:
               schema:
                 example: { "code": 200, "data": { "Details": "Chat presence set successfuly" }, "success": true } 
+  /chat/history:
+    get:
+      tags:
+        - Chat
+      summary: Get chat message history
+      description: Retrieves message history for a specific chat. Returns messages in reverse chronological order (newest first). Requires message history to be enabled on the server.
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - name: chat_jid
+          in: query
+          required: true
+          description: The JID (WhatsApp ID) of the chat to retrieve history for
+          schema:
+            type: string
+            example: "5491155553333@s.whatsapp.net"
+        - name: limit
+          in: query
+          required: false
+          description: Maximum number of messages to retrieve (default is 50)
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 1000
+            default: 50
+            example: 100
+      responses:
+        200:
+          description: Message history retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 200
+                  success:
+                    type: boolean
+                    example: true
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/definitions/HistoryMessage'
+                example:
+                  code: 200
+                  success: true
+                  data:
+                    - id: 1
+                      user_id: "abc123def456"
+                      chat_jid: "5491155553333@s.whatsapp.net"
+                      sender_jid: "5491155554444@s.whatsapp.net"
+                      message_id: "3EB0C767D26A1B5F7C83"
+                      timestamp: "2023-12-01T15:30:00Z"
+                      message_type: "text"
+                      text_content: "Hello, how are you?"
+                      media_link: ""
+                    - id: 2
+                      user_id: "abc123def456"
+                      chat_jid: "5491155553333@s.whatsapp.net"
+                      sender_jid: "5491155553333@s.whatsapp.net"
+                      message_id: "4FB1D878E37B2C6G8D94"
+                      timestamp: "2023-12-01T15:25:00Z"
+                      message_type: "image"
+                      text_content: "Check out this photo!"
+                      media_link: "https://example.com/media/image123.jpg"
+        400:
+          description: Bad request - missing or invalid parameters
+          content:
+            application/json:
+              schema:
+                example: { "code": 400, "error": "chat_jid is required", "success": false }
+        501:
+          description: Not implemented - message history is disabled
+          content:
+            application/json:
+              schema:
+                example: { "code": 501, "error": "message history is disabled", "success": false }
+        500:
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                example: { "code": 500, "error": "failed to get message history", "success": false }
   /group/create:
     post:
       tags:
@@ -1505,6 +1590,11 @@ definitions:
             type: integer
             example: 30
             description: "Retention days for the user, default is 30"
+      history:
+        type: integer
+        example: 0
+        description: "Number of messages to store in history per chat for this user. 0 means no history is saved, any positive number enables history storage for that many messages per chat. Default is 0"
+        default: 0
 
   DeleteUser:
     type: object
@@ -1512,6 +1602,46 @@ definitions:
       id:
         type: string
         example: 4e4942c7dee1deef99ab8fd9f7350de5
+  HistoryMessage:
+    type: object
+    properties:
+      id:
+        type: integer
+        description: "Unique identifier for the message in the history database"
+        example: 1
+      user_id:
+        type: string
+        description: "ID of the user who owns this message history"
+        example: "abc123def456"
+      chat_jid:
+        type: string
+        description: "WhatsApp JID of the chat where this message was sent/received"
+        example: "5491155553333@s.whatsapp.net"
+      sender_jid:
+        type: string
+        description: "WhatsApp JID of the user who sent this message"
+        example: "5491155554444@s.whatsapp.net"
+      message_id:
+        type: string
+        description: "WhatsApp message ID"
+        example: "3EB0C767D26A1B5F7C83"
+      timestamp:
+        type: string
+        format: date-time
+        description: "Timestamp when the message was sent/received"
+        example: "2023-12-01T15:30:00Z"
+      message_type:
+        type: string
+        description: "Type of message (text, image, audio, video, document, sticker, contact, location, etc.)"
+        example: "text"
+      text_content:
+        type: string
+        description: "Text content of the message (for text messages or captions)"
+        example: "Hello, how are you?"
+      media_link:
+        type: string
+        description: "Link to media file (for media messages)"
+        example: "https://example.com/media/image123.jpg"
   GroupPhoto:
     type: object
     properties:

--- a/static/dashboard/history.html
+++ b/static/dashboard/history.html
@@ -1,0 +1,936 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>WuzAPI - Chat History</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fomantic-ui@2.9.4/dist/semantic.min.css">
+  <link rel="stylesheet" href="css/app.css">
+  <style>
+    .history-container {
+      display: flex;
+      height: 100vh;
+      background: #f8f9fa;
+      font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+      font-size: 12px;
+    }
+    
+    .sidebar {
+      width: 280px;
+      background: #fff;
+      border-right: 1px solid #ddd;
+      display: flex;
+      flex-direction: column;
+    }
+    
+    .sidebar-header {
+      padding: 10px 15px;
+      border-bottom: 1px solid #ddd;
+      background: #f1f3f4;
+      color: #333;
+      font-weight: 600;
+      font-size: 12px;
+    }
+    
+    .sidebar-header h3 {
+      margin: 0;
+      font-size: 14px;
+      cursor: pointer;
+      transition: color 0.2s;
+    }
+    
+    .sidebar-header h3:hover {
+      color: #2196f3;
+    }
+    
+    .instance-selector {
+      padding: 10px;
+      border-bottom: 1px solid #ddd;
+      background: #fafafa;
+    }
+    
+    .chat-list {
+      flex: 1;
+      overflow-y: auto;
+    }
+    
+    .chat-item {
+      padding: 6px 10px;
+      border-bottom: 1px solid #f0f0f0;
+      cursor: pointer;
+      transition: background-color 0.1s;
+      font-size: 11px;
+    }
+    
+    .chat-item:hover {
+      background-color: #f0f0f0;
+    }
+    
+    .chat-item.active {
+      background-color: #e3f2fd;
+      border-left: 3px solid #2196f3;
+    }
+    
+    .chat-name {
+      font-weight: 600;
+      font-size: 12px;
+      margin-bottom: 2px;
+    }
+    
+    .chat-jid {
+      font-size: 10px;
+      color: #666;
+      font-family: monospace;
+    }
+    
+    .main-content {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      background: #fff;
+    }
+    
+    .chat-header {
+      padding: 9px 15px;
+      border-bottom: 1px solid #ddd;
+      background: #f1f3f4;
+      font-size: 13px;
+    }
+    
+    .chat-messages {
+      flex: 1;
+      overflow-y: auto;
+      background: #fff;
+    }
+    
+    .messages-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 11px;
+    }
+    
+    .message-row {
+      border-bottom: 1px solid #ddd;
+      cursor: pointer;
+      transition: background-color 0.1s;
+    }
+    
+    .message-row:hover {
+      background-color: #f8f9fa;
+    }
+    
+    .message-row.me {
+      background-color: #e8f5e8;
+    }
+    
+    .message-row.me:hover {
+      background-color: #d4edda;
+    }
+    
+    .message-row td {
+      padding: 4px 8px;
+      vertical-align: top;
+      border: none;
+    }
+    
+    .message-timestamp {
+      width: 120px;
+      color: #666;
+      font-size: 10px;
+      white-space: nowrap;
+    }
+    
+    .message-sender {
+      width: 150px;
+      font-weight: 500;
+      color: #333;
+    }
+    
+    .message-content {
+      color: #333;
+      word-break: break-word;
+      max-width: 400px;
+    }
+    
+    .message-type {
+      width: 60px;
+      font-size: 9px;
+      color: #888;
+      text-transform: uppercase;
+      padding: 2px 6px;
+      display: inline-block;
+    }
+    
+    .json-expanded {
+      background: #f8f9fa !important;
+    }
+    
+    .json-content {
+      background: #f1f3f4;
+      font-family: 'Courier New', monospace;
+      font-size: 10px;
+      white-space: pre-wrap;
+      padding: 0 5px;
+    }
+    
+    .quoted-message {
+      background: #f0f0f0;
+      border-left: 3px solid #ccc;
+      padding: 4px 8px;
+      margin: 2px 0 4px 0;
+      border-radius: 2px;
+      font-size: 10px;
+    }
+    
+    .quote-header {
+      font-weight: 600;
+      color: #666;
+      margin-bottom: 2px;
+    }
+    
+    .quote-content {
+      color: #888;
+      font-style: italic;
+    }
+    
+    .reply-content {
+      margin-top: 4px;
+    }
+    
+    .deleted-message {
+      background: #fff3e0;
+      border-left: 3px solid #ff9800;
+      padding: 4px 8px;
+      margin: 2px 0;
+      border-radius: 2px;
+      font-size: 11px;
+      color: #bf360c;
+    }
+    
+    .deleted-message s {
+      text-decoration: line-through;
+      color: #666;
+    }
+    
+    .quoted-message i {
+      color: #999;
+      font-size: 9px;
+    }
+    
+    .no-selection {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+      color: #666;
+      font-size: 16px;
+    }
+    
+    .loading {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+    }
+    
+    .error-message {
+      padding: 20px;
+      color: #d32f2f;
+      background: #ffebee;
+      border: 1px solid #ffcdd2;
+      border-radius: 4px;
+      margin: 20px;
+    }
+    
+    .media-message {
+      font-style: italic;
+      color: rgba(255, 255, 255, 0.9);
+    }
+    
+    .message.other .media-message {
+      color: #666;
+    }
+    
+    @media (max-width: 768px) {
+      .sidebar {
+        width: 250px;
+      }
+      
+      .message-bubble {
+        max-width: 85%;
+      }
+    }
+    
+    .json-view {
+      font-family: 'Courier New', monospace;
+      background: #f8f9fa;
+      border: 1px solid #e0e0e0;
+      border-radius: 4px;
+      padding: 15px;
+      margin: 10px 0;
+      overflow-x: auto;
+      white-space: pre-wrap;
+      font-size: 12px;
+      line-height: 1.4;
+    }
+    
+    .json-message {
+      background: white;
+      border: 1px solid #ddd;
+      border-radius: 4px;
+      padding: 10px;
+      margin: 5px 0;
+      font-size: 11px;
+    }
+  </style>
+</head>
+<body>
+
+<!-- Login Modal -->
+<div class="ui modal" id="loginModal">
+  <div class="header">
+    <i class="lock icon"></i>
+    Authentication Required
+  </div>
+  <div class="content">
+    <div class="ui form">
+      <div class="field">
+        <label>Access Token</label>
+        <input type="password" id="tokenInput" placeholder="Enter your user token or admin token">
+        <div class="ui info message">
+          <p>This page requires authentication. Please enter your user token or admin token to continue.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="actions">
+    <div class="ui cancel button">Cancel</div>
+    <div class="ui primary button" id="loginBtn">Login</div>
+  </div>
+</div>
+
+<div class="history-container" id="historyContainer" style="display: none;">
+  <div class="sidebar">
+    <div class="sidebar-header">
+      <h3 onclick="refreshPage()">
+        <i class="history icon"></i>
+        Chat History
+      </h3>
+    </div>
+    
+    <div class="instance-selector">
+      <label style="display: block; margin-bottom: 8px; font-weight: 600;">Instance:</label>
+      <select class="ui fluid dropdown" id="instanceSelect">
+        <option value="">Select an instance...</option>
+      </select>
+    </div>
+    
+    <div class="chat-list" id="chatList">
+      <div class="ui message">
+        <p>Select an instance to view chats</p>
+      </div>
+    </div>
+  </div>
+  
+  <div class="main-content">
+    <div class="chat-header" id="chatHeader" style="display: none;">
+      <div>
+        <strong id="chatTitle"></strong>
+        <span style="color: #666; margin-left: 10px;" id="chatJidDisplay"></span>
+        <span style="color: #888; margin-left: 10px;" id="messageCount"></span>
+      </div>
+    </div>
+    
+    <div class="chat-messages" id="chatMessages">
+      <div class="no-selection" style="padding: 40px; text-align: center; color: #666; font-size: 14px;">
+        <div style="margin-bottom: 10px; font-weight: 600;">Chat History Viewer</div>
+        <p style="margin: 0;">Select a chat on the left to see the entries and json for them.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/fomantic-ui@2.9.4/dist/semantic.min.js"></script>
+
+<script>
+let currentToken = '';
+let currentInstance = '';
+let currentChatJid = '';
+let instanceChatMap = {};
+let contactsCache = {};
+let sessionInfo = {};
+let allContacts = {};
+let groupsInfo = {};
+
+$(document).ready(function() {
+  // Initialize dropdown and checkbox
+  $('.ui.dropdown').dropdown();
+  $('.ui.checkbox').checkbox();
+  
+  // Login function
+  function performLogin() {
+    const token = $('#tokenInput').val().trim();
+    if (!token) {
+      alert('Please enter a token');
+      return false;
+    }
+    
+    currentToken = token;
+    $('#loginBtn').addClass('loading');
+    loadInstances();
+    return false; // Prevent modal from closing immediately
+  }
+  
+  // Show login modal
+  $('#loginModal').modal({
+    closable: false,
+    onApprove: function() {
+      return performLogin();
+    }
+  }).modal('show');
+  
+  // Handle login button click
+  $('#loginBtn').click(function(e) {
+    e.preventDefault();
+    performLogin();
+  });
+  
+  // Handle Enter key in token input
+  $('#tokenInput').keypress(function(e) {
+    if (e.which === 13) { // Enter key
+      e.preventDefault();
+      performLogin();
+    }
+  });
+  
+  // Instance selection handler
+  $('#instanceSelect').on('change', function() {
+    const selectedInstance = $(this).val();
+    if (selectedInstance && instanceChatMap[selectedInstance]) {
+      currentInstance = selectedInstance;
+      loadChatsForInstance(selectedInstance);
+    } else {
+      $('#chatList').html('<div class="ui message"><p>No chats found for this instance</p></div>');
+      clearChatView();
+    }
+  });
+  
+
+});
+
+// Function to refresh the page and reinitialize everything
+function refreshPage() {
+  // Clear all data
+  currentInstance = '';
+  currentChatJid = '';
+  instanceChatMap = {};
+  contactsCache = {};
+  sessionInfo = {};
+  allContacts = {};
+  groupsInfo = {};
+  
+  // Reset UI
+  $('#instanceSelect').dropdown('clear');
+  $('#chatList').html('<div class="ui message"><p>Select an instance to view chats</p></div>');
+  clearChatView();
+  
+  // Reload all data
+  loadInstances();
+}
+
+function loadInstances() {
+  showLoading();
+  
+  // Load all necessary data in parallel
+  Promise.all([
+    loadChatHistory(),
+    loadSessionStatus(),
+    loadContacts(),
+    loadGroups()
+  ]).then(() => {
+    populateInstanceDropdown();
+    $('#historyContainer').show();
+    $('#loginModal').modal('hide');
+    $('#loginBtn').removeClass('loading');
+    
+    // Clear loading message and show default state
+    clearChatView();
+  }).catch(error => {
+    $('#loginBtn').removeClass('loading');
+    if (error.status === 401) {
+      alert('Invalid token. Please try again.');
+      $('#tokenInput').focus();
+    } else {
+      alert('Failed to load data: ' + (error.message || 'Unknown error'));
+    }
+    
+    // Clear loading message even on error
+    clearChatView();
+  });
+}
+
+function loadChatHistory() {
+  return new Promise((resolve, reject) => {
+    $.ajax({
+      url: '/chat/history?chat_jid=index',
+      method: 'GET',
+      headers: {
+        'token': currentToken
+      },
+      success: function(response) {
+        instanceChatMap = response.data || response;
+        resolve();
+      },
+      error: function(xhr) {
+        reject(xhr);
+      }
+    });
+  });
+}
+
+function loadSessionStatus() {
+  return new Promise((resolve, reject) => {
+    $.ajax({
+      url: '/session/status',
+      method: 'GET',
+      headers: {
+        'token': currentToken
+      },
+      success: function(response) {
+        sessionInfo = response.data || response;
+        console.log('Session info loaded:', sessionInfo);
+        resolve();
+      },
+      error: function(xhr) {
+        console.warn('Failed to load session status:', xhr);
+        // Don't reject - session status is optional
+        resolve();
+      }
+    });
+  });
+}
+
+function loadContacts() {
+  return new Promise((resolve, reject) => {
+    $.ajax({
+      url: '/user/contacts',
+      method: 'GET',
+      headers: {
+        'token': currentToken
+      },
+      success: function(response) {
+        allContacts = response.data || response;
+        console.log('Contacts loaded:', Object.keys(allContacts).length, 'contacts');
+        resolve();
+      },
+      error: function(xhr) {
+        console.warn('Failed to load contacts:', xhr);
+        // Don't reject - contacts are optional
+        resolve();
+      }
+    });
+  });
+}
+
+function loadGroups() {
+  return new Promise((resolve, reject) => {
+    $.ajax({
+      url: '/group/list',
+      method: 'GET',
+      headers: {
+        'token': currentToken
+      },
+      success: function(response) {
+        const groupsData = response.data || response;
+        // Convert groups array to JID -> info mapping
+        if (groupsData.Groups) {
+          groupsData.Groups.forEach(group => {
+            groupsInfo[group.JID] = group;
+          });
+        }
+        console.log('Groups loaded:', Object.keys(groupsInfo).length, 'groups');
+        resolve();
+      },
+      error: function(xhr) {
+        console.warn('Failed to load groups:', xhr);
+        // Don't reject - groups are optional
+        resolve();
+      }
+    });
+  });
+}
+
+function populateInstanceDropdown() {
+  const select = $('#instanceSelect');
+  select.empty().append('<option value="">Select an instance...</option>');
+  
+  Object.keys(instanceChatMap).forEach(instance => {
+    const chatCount = instanceChatMap[instance].length;
+    
+    // Get display name for instance
+    let instanceDisplayName = instance;
+    
+    // If this is the current session, use the name from session info
+    if (sessionInfo.id === instance && sessionInfo.name) {
+      instanceDisplayName = `${sessionInfo.name} (You)`;
+    } else {
+      // For other instances, show a shortened version of the ID
+      instanceDisplayName = `Instance ${instance.substring(0, 8)}...`;
+    }
+    
+    select.append(`<option value="${instance}">${instanceDisplayName} (${chatCount} chats)</option>`);
+  });
+  
+  // Auto-select current user's instance first if it exists
+  const instances = Object.keys(instanceChatMap);
+  if (sessionInfo.id && instances.includes(sessionInfo.id)) {
+    select.val(sessionInfo.id).trigger('change');
+  } else if (instances.length === 1) {
+    select.val(instances[0]).trigger('change');
+  }
+  
+  select.dropdown('refresh');
+}
+
+function loadChatsForInstance(instance) {
+  const chats = instanceChatMap[instance] || [];
+  
+  if (chats.length === 0) {
+    $('#chatList').html('<div class="ui message"><p>No chats found for this instance</p></div>');
+    return;
+  }
+  
+  // Render the chats with timestamps
+  renderChatList(instance, chats);
+}
+
+function renderChatList(instance, chats) {
+  const chatList = $('#chatList');
+  chatList.empty();
+  
+  chats.forEach(chat => {
+    // Handle both new format (object) and old format (string) for backward compatibility
+    const chatJid = typeof chat === 'string' ? chat : chat.chat_jid;
+    
+    // Parse timestamp with better handling for the API format
+    let lastUpdated = null;
+    if (typeof chat === 'object' && chat.last_updated) {
+      const timestamp = chat.last_updated;
+      
+      // Handle the format: "2025-09-28 14:12:36.233262431 +0530 IST"
+      // Convert to ISO format that JavaScript can parse
+      const isoTimestamp = timestamp
+        .replace(' +0530 IST', '+05:30')  // Fix timezone format
+        .replace(' ', 'T');               // Replace space with T
+      
+      lastUpdated = new Date(isoTimestamp);
+      
+      // If still invalid, try without nanoseconds
+      if (isNaN(lastUpdated.getTime())) {
+        const withoutNanos = isoTimestamp.replace(/\.\d+/, '');
+        lastUpdated = new Date(withoutNanos);
+      }
+      
+      // If still invalid, set to null
+      if (isNaN(lastUpdated.getTime())) {
+        console.warn('Failed to parse timestamp:', timestamp);
+        lastUpdated = null;
+      }
+    }
+    
+    // Get proper display name
+    const displayName = getDisplayName(chatJid);
+    const isGroup = chatJid.includes('@g.us');
+    
+    // Format timestamp
+    const timeStr = lastUpdated ? lastUpdated.toLocaleString() : '';
+    
+    const chatItem = $(`
+      <div class="chat-item" data-chat-jid="${chatJid}">
+        <div class="chat-name">
+          <i class="${isGroup ? 'users' : 'user'} icon"></i>
+          ${displayName}
+        </div>
+        <div class="chat-jid" style="font-size: 11px; color: #888; margin-top: 2px;">${chatJid}</div>
+        ${timeStr ? `<div class="chat-timestamp" style="font-size: 11px; color: #999; margin-top: 4px;">
+          <i class="clock icon"></i>${timeStr}
+        </div>` : ''}
+      </div>
+    `);
+    
+    chatItem.click(function() {
+      $('.chat-item').removeClass('active');
+      $(this).addClass('active');
+      loadChatMessages(instance, chatJid, displayName);
+    });
+    
+    chatList.append(chatItem);
+  });
+}
+
+function loadChatMessages(instance, chatJid, displayName) {
+  currentChatJid = chatJid;
+  
+  // Update header with better info
+  const properDisplayName = getDisplayName(chatJid);
+  const isGroup = chatJid.includes('@g.us');
+  
+  let headerInfo = `<i class="${isGroup ? 'users' : 'user'} icon"></i>${properDisplayName}`;
+  if (isGroup && groupsInfo[chatJid]) {
+    const participantCount = groupsInfo[chatJid].Participants ? groupsInfo[chatJid].Participants.length : 0;
+    headerInfo += ` <span style="font-size: 12px; color: #666;">(${participantCount} participants)</span>`;
+  }
+  
+  $('#chatTitle').html(headerInfo);
+  $('#chatJidDisplay').text(chatJid);
+  $('#chatHeader').show();
+  
+  // Show loading
+  $('#chatMessages').html('<div class="loading"><div class="ui active loader"></div></div>');
+  
+  $.ajax({
+    url: `/chat/history?chat_jid=${encodeURIComponent(chatJid)}&limit=100`,
+    method: 'GET',
+    headers: {
+      'token': currentToken
+    },
+    success: function(response) {
+      const messages = response.data || response; // Handle both wrapped and unwrapped responses
+      window.currentMessages = messages; // Store for toggle functionality
+      renderMessages(messages);
+    },
+    error: function(xhr) {
+      $('#chatMessages').html(`
+        <div class="error-message">
+          Failed to load messages: ${xhr.responseJSON?.error || 'Unknown error'}
+        </div>
+      `);
+    }
+  });
+}
+
+function renderMessages(messages) {
+  const container = $('#chatMessages');
+  container.empty();
+  
+  if (messages.length === 0) {
+    container.html('<div style="padding: 20px; text-align: center; color: #666;">No messages found in this chat</div>');
+    return;
+  }
+  
+  // Update message count in header
+  $('#messageCount').text(`(${messages.length} messages)`);
+  
+  // Create message ID to message mapping for quote lookup
+  const messageMap = {};
+  messages.forEach(msg => {
+    if (msg.message_id) {
+      messageMap[msg.message_id] = msg;
+    }
+  });
+  
+  // Create table
+  const table = $('<table class="messages-table"></table>');
+  
+  // Reverse messages to show oldest first
+  const sortedMessages = [...messages].reverse();
+  
+  sortedMessages.forEach((message, index) => {
+    const isMe = isMyMessage(message.sender_jid);
+    const timestamp = new Date(message.timestamp).toLocaleString();
+    
+    // Get sender display name
+    const senderDisplayName = getSenderDisplayName(message.sender_jid);
+    
+    // Process message content for quotes and replies
+    const processedContent = processMessageContent(message, messageMap);
+    
+    // Create row
+    const row = $(`
+      <tr class="message-row ${isMe ? 'me' : ''}" data-message-index="${index}">
+        <td class="message-timestamp">${timestamp}</td>
+        <td class="message-sender">${senderDisplayName}</td>
+        <td class="message-type">${message.message_type}</td>
+        <td class="message-content">${processedContent}</td>
+      </tr>
+    `);
+    
+    // Add click handler to expand JSON
+    row.click(function(e) {
+      e.preventDefault();
+      toggleMessageJson($(this), message);
+    });
+    
+    table.append(row);
+  });
+  
+  container.append(table);
+  
+  // Scroll to bottom to show most recent messages
+  setTimeout(() => {
+    container.scrollTop(container[0].scrollHeight);
+  }, 100);
+}
+
+function processMessageContent(message, messageMap) {
+  let content = message.text_content || '';
+  
+  // Handle delete message types
+  if (message.message_type === 'delete') {
+    const deletedMessageId = message.text_content;
+    const deletedMessage = messageMap[deletedMessageId];
+    
+    if (deletedMessage) {
+      let deletedContent = deletedMessage.text_content || '[Media message]';
+      
+      // Remove any quote pattern from the deleted content
+      const quotePattern = /^>\s*([A-Z0-9]{16,})\s*\n(.*)$/s;
+      const match = deletedContent.match(quotePattern);
+      if (match) {
+        deletedContent = match[2];
+      }
+      
+      // Truncate if too long
+      if (deletedContent.length > 100) {
+        deletedContent = deletedContent.substring(0, 100) + '...';
+      }
+      
+      return `<div class="deleted-message"><s title="This message was deleted">${deletedContent}</s> <span style="color: #888; font-size: 10px;">(deleted)</span></div>`;
+    } else {
+      return `<div class="deleted-message"><i>Message deleted (original not in history)</i></div>`;
+    }
+  }
+  
+  // Handle media messages
+  if (message.media_link) {
+    content = `[Media: ${message.media_link}]`;
+  }
+  if (!content && message.message_type !== 'delete') {
+    content = '[Media message]';
+  }
+  
+  // Check if this is a quoted/reply message
+  // Pattern: > followed by [A-Z0-9] 16+ characters, then newline
+  const quotePattern = /^>\s*([A-Z0-9]{16,})\s*\n(.*)$/s;
+  const match = content.match(quotePattern);
+  
+  if (match) {
+    const quotedMessageId = match[1];
+    const actualContent = match[2];
+    
+    // Look up the quoted message
+    const quotedMessage = messageMap[quotedMessageId];
+    
+    let quoteDisplay = '';
+    if (quotedMessage) {
+      const quotedSender = getSenderDisplayName(quotedMessage.sender_jid);
+      let quotedContent = quotedMessage.text_content || '[Media message]';
+      
+      // Remove any quote pattern from the quoted content itself (nested quotes)
+      const nestedQuoteMatch = quotedContent.match(quotePattern);
+      if (nestedQuoteMatch) {
+        quotedContent = nestedQuoteMatch[2]; // Extract the actual content after the quote ID
+      }
+      
+      // Truncate long quoted content
+      if (quotedContent.length > 100) {
+        quotedContent = quotedContent.substring(0, 100) + '...';
+      }
+      
+      quoteDisplay = `<div class="quoted-message">
+        <div class="quote-header">${quotedSender}:</div>
+        <div class="quote-content">${quotedContent}</div>
+      </div>`;
+    } else {
+      quoteDisplay = '<div class="quoted-message"><i>no context in history</i></div>';
+    }
+    
+    return quoteDisplay + '<div class="reply-content">' + actualContent + '</div>';
+  }
+  
+  return content;
+}
+
+function toggleMessageJson(row, message) {
+  const nextRow = row.next();
+  
+  // If JSON is already expanded, collapse it
+  if (nextRow.hasClass('json-expanded')) {
+    nextRow.remove();
+    return;
+  }
+  
+  // Remove any other expanded JSON
+  $('.json-expanded').remove();
+  
+  // Create JSON expansion
+  const jsonRow = $(`
+    <tr class="json-expanded">
+      <td colspan="4">
+        <div class="json-content">${JSON.stringify(message, null, 2)}</div>
+      </td>
+    </tr>
+  `);
+  
+  row.after(jsonRow);
+}
+
+function clearChatView() {
+  $('#chatHeader').hide();
+  $('#chatMessages').html('<div style="padding: 40px; text-align: center; color: #666; font-size: 14px;"><div style="margin-bottom: 10px; font-weight: 600;">Chat History Viewer</div><p style="margin: 0;">Select a chat on the left to see the entries and json for them.</p></div>');
+  currentChatJid = '';
+}
+
+function showLoading() {
+  $('#chatMessages').html('<div class="loading"><div class="ui active loader"></div><p style="text-align: center; margin-top: 20px;">Loading chat history, contacts, and groups...</p></div>');
+}
+
+// Helper function to check if a message is from the current user
+function isMyMessage(senderJid) {
+  if (senderJid === 'me') return true;
+  
+  // Check if sender matches our session JID
+  if (sessionInfo.jid) {
+    // Extract base number from both JIDs (before the : and @)
+    // Handle both "919480240751:20@s.whatsapp.net" and "919480240751@s.whatsapp.net" formats
+    const myBaseJid = sessionInfo.jid.split('@')[0].split(':')[0]; // "919480240751"
+    const senderBaseJid = senderJid.split('@')[0].split(':')[0];   // "919480240751"
+    
+    return myBaseJid === senderBaseJid;
+  }
+  
+  return false;
+}
+
+// Helper function to get display name for a JID
+function getDisplayName(jid) {
+  // Check if it's a group
+  if (jid.includes('@g.us')) {
+    if (groupsInfo[jid]) {
+      return groupsInfo[jid].Name;
+    }
+  }
+  
+  // Check contacts
+  if (allContacts[jid]) {
+    const contact = allContacts[jid];
+    return contact.PushName || contact.FullName || contact.FirstName || jid;
+  }
+  
+  // Return JID as fallback
+  return jid;
+}
+
+// Helper function to get sender display name in group chats
+function getSenderDisplayName(senderJid) {
+  if (isMyMessage(senderJid)) {
+    return sessionInfo.name || 'Me';
+  }
+  
+  return getDisplayName(senderJid);
+}
+</script>
+
+</body>
+</html>

--- a/static/dashboard/index.html
+++ b/static/dashboard/index.html
@@ -565,6 +565,11 @@
             <option value="All">All Events</option>
           </select>
         </div>
+        <div class="field">
+          <label>Message History</label>
+          <input type="number" name="history" min="0" value="0" placeholder="0">
+          <small>Number of messages to store in history per chat for this instance. Set to 0 to disable message history.</small>
+        </div>
 
         <!-- Proxy Configuration -->
         <h4 class="ui dividing header">Proxy Configuration (Optional)</h4>

--- a/static/dashboard/js/app.js
+++ b/static/dashboard/js/app.js
@@ -333,6 +333,14 @@ document.addEventListener('DOMContentLoaded', function() {
           prompt: 'Please select at least one event'
         }]
       },
+      history: {
+        identifier: 'history',
+        optional: true,
+        rules: [{
+          type: 'integer[0..]',
+          prompt: 'History must be a non-negative integer'
+        }]
+      },
       proxy_url: {
         identifier: 'proxy_url',
         optional: true,
@@ -447,6 +455,7 @@ async function addInstance(data) {
     events: data.events.join(','),
     webhook: data.webhook_url || '',
     expiration: 0,
+    history: parseInt(data.history) || 0,
     proxyConfig: proxyConfig,
     s3Config: s3Config
   };
@@ -1145,6 +1154,10 @@ function populateInstances(instances) {
                           <div class="item">
                               <div class="header">Subscribed Events</div>
                               <div class="content">${instance.events || 'Not configured'}</div>
+                          </div>
+                          <div class="item">
+                              <div class="header">Message History</div>
+                              <div class="content">${instance.history || 0} messages per chat</div>
                           </div>
                           <div class="item">
                               <div class="header">Proxy</div>

--- a/static/docs/index.html
+++ b/static/docs/index.html
@@ -847,6 +847,95 @@
                     </tbody>
                 </table>
             </div>
+
+            <div class="endpoint">
+                <h3><span class="method get">GET</span> <span class="path">/chat/history</span></h3>
+                <p>Recupera o histórico de mensagens de um chat específico. Retorna as mensagens em ordem cronológica reversa (mais recentes primeiro).</p>
+                
+                <h4>Parâmetros de Query:</h4>
+                <table class="api-table">
+                    <thead>
+                        <tr>
+                            <th>Parâmetro</th>
+                            <th>Tipo</th>
+                            <th>Descrição</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td class="required">chat_jid</td>
+                            <td>string</td>
+                            <td>JID (ID do WhatsApp) do chat para recuperar o histórico</td>
+                        </tr>
+                        <tr>
+                            <td>limit</td>
+                            <td>integer</td>
+                            <td>Número máximo de mensagens a recuperar (padrão: 50, máximo: 1000)</td>
+                        </tr>
+                    </tbody>
+                </table>
+                
+                <h4>Exemplo de Requisição:</h4>
+                <pre><code class="language-bash">GET /chat/history?chat_jid=5491155553935@s.whatsapp.net&limit=10</code></pre>
+                
+                <h4>Resposta de Sucesso:</h4>
+                <pre><code class="language-json">{
+  "code": 200,
+  "success": true,
+  "data": [
+    {
+      "id": 1,
+      "user_id": "abc123def456",
+      "chat_jid": "5491155553935@s.whatsapp.net",
+      "sender_jid": "5491155554444@s.whatsapp.net",
+      "message_id": "3EB0C767D26A1B5F7C83",
+      "timestamp": "2023-12-01T15:30:00Z",
+      "message_type": "text",
+      "text_content": "Olá, como você está?",
+      "media_link": ""
+    },
+    {
+      "id": 2,
+      "user_id": "abc123def456", 
+      "chat_jid": "5491155553935@s.whatsapp.net",
+      "sender_jid": "5491155553935@s.whatsapp.net",
+      "message_id": "4FB1D878E37B2C6G8D94",
+      "timestamp": "2023-12-01T15:25:00Z",
+      "message_type": "image",
+      "text_content": "Veja esta foto!",
+      "media_link": "https://example.com/media/image123.jpg"
+    }
+  ]
+}</code></pre>
+
+                <h4>Possíveis Erros:</h4>
+                <table class="api-table">
+                    <thead>
+                        <tr>
+                            <th>Código</th>
+                            <th>Descrição</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>400</td>
+                            <td>Requisição inválida - parâmetro chat_jid obrigatório</td>
+                        </tr>
+                        <tr>
+                            <td>501</td>
+                            <td>Não implementado - histórico de mensagens está desabilitado</td>
+                        </tr>
+                        <tr>
+                            <td>500</td>
+                            <td>Erro interno do servidor</td>
+                        </tr>
+                    </tbody>
+                </table>
+                
+                <div class="alert alert-info">
+                    <strong>Nota:</strong> Este endpoint requer que o histórico de mensagens esteja habilitado no servidor. O histórico é salvo automaticamente para mensagens enviadas e recebidas após a ativação desta funcionalidade.
+                </div>
+            </div>
         </section>
 
         <section id="user">

--- a/wmiau.go
+++ b/wmiau.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -37,6 +38,7 @@ type MyClient struct {
 	token          string
 	subscriptions  []string
 	db             *sqlx.DB
+	s              *server
 }
 
 func sendToGlobalWebHook(jsonData []byte, token string, userID string) {
@@ -201,7 +203,7 @@ func checkIfSubscribedToEvent(subscribedEvents []string, eventType string, userI
 
 // Connects to Whatsapp Websocket on server startup if last state was connected
 func (s *server) connectOnStartup() {
-	rows, err := s.db.Queryx("SELECT id,name,token,jid,webhook,events,proxy_url,CASE WHEN s3_enabled THEN 'true' ELSE 'false' END AS s3_enabled,media_delivery FROM users WHERE connected=1")
+	rows, err := s.db.Queryx("SELECT id,name,token,jid,webhook,events,proxy_url,CASE WHEN s3_enabled THEN 'true' ELSE 'false' END AS s3_enabled,media_delivery,COALESCE(history, 0) as history FROM users WHERE connected=1")
 	if err != nil {
 		log.Error().Err(err).Msg("DB Problem")
 		return
@@ -217,7 +219,8 @@ func (s *server) connectOnStartup() {
 		proxy_url := ""
 		s3_enabled := ""
 		media_delivery := ""
-		err = rows.Scan(&txtid, &name, &token, &jid, &webhook, &events, &proxy_url, &s3_enabled, &media_delivery)
+		var history int
+		err = rows.Scan(&txtid, &name, &token, &jid, &webhook, &events, &proxy_url, &s3_enabled, &media_delivery, &history)
 		if err != nil {
 			log.Error().Err(err).Msg("DB Problem")
 			return
@@ -233,6 +236,7 @@ func (s *server) connectOnStartup() {
 				"Events":        events,
 				"S3Enabled":     s3_enabled,
 				"MediaDelivery": media_delivery,
+				"History":       fmt.Sprintf("%d", history),
 			}}
 			userinfocache.Set(token, v, cache.NoExpiration)
 			// Gets and set subscription to webhook events
@@ -382,7 +386,7 @@ func (s *server) startClient(userID string, textjid string, token string, subscr
 	store.DeviceProps.Os = osName
 
 	clientManager.SetWhatsmeowClient(userID, client)
-	mycli := MyClient{client, 1, userID, token, subscriptions, s.db}
+	mycli := MyClient{client, 1, userID, token, subscriptions, s.db, s}
 	mycli.eventHandlerID = mycli.WAClient.AddEventHandler(mycli.myEventHandler)
 
 	// CORREÇÃO: Armazenar o MyClient no clientManager
@@ -979,6 +983,135 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 				} else {
 					log.Info().Str("path", tmpPath).Msg("Temporary file deleted")
 				}
+			}
+		}
+
+		// Save message to history regardless of skipMedia setting
+		// Get user's history setting from cache
+		var historyLimit int
+		userinfo, found := userinfocache.Get(mycli.token)
+		if found {
+			historyStr := userinfo.(Values).Get("History")
+			historyLimit, _ = strconv.Atoi(historyStr)
+		} else {
+			log.Warn().Str("userID", mycli.userID).Msg("User info not found in cache, skipping history")
+			historyLimit = 0
+		}
+		
+		if historyLimit > 0 {
+			messageType := "text"
+			textContent := ""
+			mediaLink := ""
+			caption := ""
+			replyToMessageID := ""
+
+			// Check for delete messages first
+			if protocolMsg := evt.Message.GetProtocolMessage(); protocolMsg != nil && protocolMsg.GetType() == 0 {
+				messageType = "delete"
+				if protocolMsg.GetKey() != nil {
+					textContent = protocolMsg.GetKey().GetID() // Store the deleted message ID
+				}
+				log.Info().Str("deletedMessageID", textContent).Str("messageID", evt.Info.ID).Msg("Delete message detected")
+			// Check for reactions
+			} else if reaction := evt.Message.GetReactionMessage(); reaction != nil {
+				messageType = "reaction"
+				replyToMessageID = reaction.GetKey().GetID()
+				textContent = reaction.GetText() // This will be the emoji
+			} else if img := evt.Message.GetImageMessage(); img != nil {
+				messageType = "image"
+				caption = img.GetCaption()
+			} else if video := evt.Message.GetVideoMessage(); video != nil {
+				messageType = "video"
+				caption = video.GetCaption()
+			} else if audio := evt.Message.GetAudioMessage(); audio != nil {
+				messageType = "audio"
+			} else if doc := evt.Message.GetDocumentMessage(); doc != nil {
+				messageType = "document"
+				caption = doc.GetCaption()
+			} else if sticker := evt.Message.GetStickerMessage(); sticker != nil {
+				messageType = "sticker"
+			} else if contact := evt.Message.GetContactMessage(); contact != nil {
+				messageType = "contact"
+				textContent = contact.GetDisplayName()
+			} else if location := evt.Message.GetLocationMessage(); location != nil {
+				messageType = "location"
+				textContent = location.GetName()
+			}
+
+			// Extract text content for non-reaction and non-delete messages
+			if messageType != "reaction" && messageType != "delete" {
+				if conv := evt.Message.GetConversation(); conv != "" {
+					textContent = conv
+				} else if ext := evt.Message.GetExtendedTextMessage(); ext != nil {
+					textContent = ext.GetText()
+					// Check if this is a reply to another message
+					if contextInfo := ext.GetContextInfo(); contextInfo != nil && contextInfo.GetStanzaId() != "" {
+						replyToMessageID = contextInfo.GetStanzaId()
+					}
+				} else {
+					textContent = caption
+				}
+				
+				// Set default text content for media messages without captions
+				if textContent == "" {
+					switch messageType {
+					case "image":
+						textContent = ":image:"
+					case "video":
+						textContent = ":video:"
+					case "audio":
+						textContent = ":audio:"
+					case "document":
+						textContent = ":document:"
+					case "sticker":
+						textContent = ":sticker:"
+					case "contact":
+						if textContent == "" {
+							textContent = ":contact:"
+						}
+					case "location":
+						if textContent == "" {
+							textContent = ":location:"
+						}
+					}
+				}
+			}
+
+			// Check for replies in regular conversation messages too
+			if messageType == "text" && replyToMessageID == "" {
+				// For regular text messages, check if there's context info indicating a reply
+				// This might be available in the message context
+				if conv := evt.Message.GetConversation(); conv != "" {
+					// Check if the message has reply context (this depends on WhatsApp message structure)
+					// For now, we'll rely on ExtendedTextMessage for reply detection
+				}
+			}
+
+			// Format text content for replies (including reactions)
+			if replyToMessageID != "" && textContent != "" {
+				textContent = fmt.Sprintf(">%s\n%s", replyToMessageID, textContent)
+			}
+
+			// Try to get media link from S3 data if available
+			if s3Data, ok := postmap["s3"].(map[string]interface{}); ok {
+				if url, ok := s3Data["url"].(string); ok {
+					mediaLink = url
+				}
+			}
+
+			// Only save if there's meaningful content (including delete messages)
+			if textContent != "" || mediaLink != "" || (messageType != "text" && messageType != "reaction") || messageType == "delete" {
+				err := mycli.s.saveMessageToHistory(mycli.userID, evt.Info.Chat.String(), evt.Info.Sender.String(), evt.Info.ID, messageType, textContent, mediaLink)
+				if err != nil {
+					log.Error().Err(err).Msg("Failed to save message to history")
+				} else {
+					err = mycli.s.trimMessageHistory(mycli.userID, evt.Info.Chat.String(), historyLimit)
+					if err != nil {
+						log.Error().Err(err).Msg("Failed to trim message history")
+					}
+				}
+			} else {
+				log.Debug().Str("messageType", messageType).Str("messageID", evt.Info.ID).Msg("Skipping empty message from history")
 			}
 		}
 


### PR DESCRIPTION
Implement message history logging.
 - when turned on via history parameter being non 0. off by default.
 - updated spec and docs to show usage.
 - implement /dashboard/history.html as a viewer for a given token, to
   see all instances, chats and logged history.

A simple history viewer as well:

<img width="1027" height="761" alt="Screenshot 2025-09-28 7 56 50 PM (1)" src="https://github.com/user-attachments/assets/874255bd-0793-4a64-a446-d3824622fbe8" />
