### PR TITLE
Fix: RabbitMQ connection string encoding

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -24,5 +24,5 @@ WUZAPI_GLOBAL_WEBHOOK=https://example.com/webhook
 WEBHOOK_FORMAT=json
 
 # RabbitMQ configuration Optional
-RABBITMQ_URL=amqp://wuzapi:wuzapi@localhost:5672/
+RABBITMQ_URL=amqp://wuzapi:wuzapi@localhost:5672/%2F
 RABBITMQ_QUEUE=whatsapp_events


### PR DESCRIPTION
This PR fixes the RabbitMQ connection string in the `.env` file by adding the encoded value `%2F` at the end of the URL.  

Without this parameter, the container was unable to connect to RabbitMQ. After adding `%2F`, the connection worked correctly.

---

## Changes
**Before:**
```env
RABBITMQ_URL=amqp://wuzapi:wuzapi@localhost:5672/
```

**After:**
```env
RABBITMQ_URL=amqp://wuzapi:wuzapi@localhost:5672/%2F
```