### PR TITLE
Ensure persistence of RabbitMQ queue

### DIFF
--- a/docker-compose-swarm.yaml
+++ b/docker-compose-swarm.yaml
@@ -48,6 +48,7 @@ services:
   # RabbitMQ service OPTIONAL
   rabbitmq:
     image: rabbitmq:3-management
+    hostname: rabbitmq
     networks:
       - network_public
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
 
   rabbitmq:
     image: rabbitmq:3-management
+    hostname: rabbitmq
     environment:
       RABBITMQ_DEFAULT_USER: wuzapi
       RABBITMQ_DEFAULT_PASS: wuzapi

--- a/rabbitmq.go
+++ b/rabbitmq.go
@@ -75,8 +75,9 @@ func PublishToRabbit(data []byte, queueOverride ...string) error {
 		false,     // mandatory
 		false,     // immediate
 		amqp091.Publishing{
-			ContentType: "application/json",
-			Body:        data,
+			ContentType:  "application/json",
+			Body:         data,
+			DeliveryMode: amqp091.Persistent,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
**Issue description**
I noticed several problems with the RabbitMQ queue:

1. The queue created by WuzAPI is deleted after restarting the RabbitMQ container even despite “**durable:true**” parameter.
2. Messages sent to the RabbitMQ queue do not have Persistent mode.

---
### Issue 1
This issue is related to the fact that RabbitMQ creates files inside the container whose names are tied to the container's hostname. This means that by default, after restarting the container, the hostname changes and the data is no longer valid.

Example:
```bash
root@ac15975e15e9:~# ls -1 /var/lib/rabbitmq/mnesia/
rabbit@ac15975e15e9
rabbit@ac15975e15e9-feature_flags
rabbit@ac15975e15e9-plugins-expand
rabbit@ac15975e15e9.pid
```

Therefore, it is important to keep the hostname constant. To do this, I added an additional “**hostname**” value to the **_docker-compose.yml_** and **_docker-compose-swarm.yaml_** configurations, which allows the host name to be retained even after a reboot.

---

### Issue 2
After completing the first step, the queue created by WuzAPI was preserved even after restarting the RabbitMQ container. However, I noticed that messages from this queue were still not preserved after the restart.

The problem was that RabbitMQ only stores messages in its queues that explicitly have the value “**Persistent**” in their **DeliveryMode**. So I added the **DeliveryMode** parameter to _**rabbitmq.go**_, and after that, all messages began to be stored successfully even after restarting RabbitMQ.
