### PR TITLE
feat: dispatch QR timeout event to webhook

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -22,6 +22,7 @@ var supportedEventTypes = []string{
 	"ConnectFailure",
 	"KeepAliveRestored",
 	"KeepAliveTimeout",
+	"QRTimeout",
 	"LoggedOut",
 	"ClientOutdated",
 	"TemporaryBan",

--- a/static/docs/index.html
+++ b/static/docs/index.html
@@ -629,6 +629,7 @@
                         <li><code>PairSuccess</code> - Pairing successful</li>
                         <li><code>PairError</code> - Pairing error</li>
                         <li><code>QR</code> - QR code generated</li>
+                        <li><code>QRTimeout</code> - QR code timeout</li>
                         <li><code>QRScannedWithoutMultidevice</code> - QR scanned without multi-device</li>
                     </ul>
                 </div>

--- a/wmiau.go
+++ b/wmiau.go
@@ -489,6 +489,12 @@ func (s *server) startClient(userID string, textjid string, token string, subscr
 
 				} else if evt.Event == "timeout" {
 					// Clear QR code from DB on timeout
+					// Send webhook notifying QR timeout before cleanup
+					postmap := make(map[string]interface{})
+					postmap["event"] = evt.Event
+					postmap["type"] = "QRTimeout"
+					sendEventWithWebHook(&mycli, postmap, "")
+
 					sqlStmt := `UPDATE users SET qrcode='' WHERE id=$1`
 					_, err := s.db.Exec(sqlStmt, userID)
 					if err != nil {


### PR DESCRIPTION
Adds a new QR pairing timeout webhook event and updates constants and docs.

## Motivation
When the QR code pairing window expires, clients had no explicit webhook event to react (e.g., prompt re-generation). This PR emits a dedicated event so integrators can handle the timeout gracefully.

## Changes
* Emit QRTimeout event on QR code timeout in wmiau.go (before cleanup).
* Add QRTimeout to supportedEventTypes in constants.go.
* Document QRTimeout in static/docs/index.html under “Connection and Session”.
