### PR TITLE
Set proxy_url to empty string instead of NULL when disabling proxy.

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -4676,7 +4676,7 @@ func (s *server) EditUser() http.HandlerFunc {
 			if user.ProxyConfig.Enabled {
 				addField("proxy_url", user.ProxyConfig.ProxyURL, true)
 			} else {
-				addField("proxy_url", nil, true)
+				addField("proxy_url", "", true)
 			}
 		}
 


### PR DESCRIPTION
2025-10-29 21:29:04 -03:00 ERROR DB Problem error="sql: Scan error on column index 6, name \"proxy_url\": converting NULL to string is unsupported" role=wuzapi