### PR TITLE
Enable setting a custom data directory via -datadir=/path/to/data

### DIFF
--- a/db.go
+++ b/db.go
@@ -22,8 +22,8 @@ type DatabaseConfig struct {
 	SSLMode  string
 }
 
-func InitializeDatabase(exPath string) (*sqlx.DB, error) {
-	config := getDatabaseConfig(exPath)
+func InitializeDatabase(exPath, dataDirFlag string) (*sqlx.DB, error) {
+	config := getDatabaseConfig(exPath, dataDirFlag)
 
 	if config.Type == "postgres" {
 		return initializePostgres(config)
@@ -31,7 +31,7 @@ func InitializeDatabase(exPath string) (*sqlx.DB, error) {
 	return initializeSQLite(config)
 }
 
-func getDatabaseConfig(exPath string) DatabaseConfig {
+func getDatabaseConfig(exPath, dataDirFlag string) DatabaseConfig {
 	dbUser := os.Getenv("DB_USER")
 	dbPassword := os.Getenv("DB_PASSWORD")
 	dbName := os.Getenv("DB_NAME")
@@ -58,9 +58,15 @@ func getDatabaseConfig(exPath string) DatabaseConfig {
 		}
 	}
 
+	// Use datadir flag if provided, otherwise fall back to executable directory
+	dataPath := exPath
+	if dataDirFlag != "" {
+		dataPath = dataDirFlag
+	}
+
 	return DatabaseConfig{
 		Type: "sqlite",
-		Path: filepath.Join(exPath, "dbdata"),
+		Path: filepath.Join(dataPath, "dbdata"),
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -60,6 +60,7 @@ var (
 	globalWebhook       = flag.String("globalwebhook", "", "Global webhook URL to receive all events from all users")
 	versionFlag         = flag.Bool("version", false, "Display version information and exit")
 	mode                = flag.String("mode", "http", "Server mode: http or stdio")
+	dataDir             = flag.String("datadir", "", "Data directory for database and session files (defaults to executable directory)")
 
 	globalHMACKeyEncrypted []byte
 
@@ -348,7 +349,7 @@ func main() {
 	}
 	exPath := filepath.Dir(ex)
 
-	db, err := InitializeDatabase(exPath)
+	db, err := InitializeDatabase(exPath, *dataDir)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to initialize database")
 		os.Exit(1)
@@ -376,7 +377,7 @@ func main() {
 	}
 
 	// Get database configuration
-	config := getDatabaseConfig(exPath)
+	config := getDatabaseConfig(exPath, *dataDir)
 	var storeConnStr string
 	if config.Type == "postgres" {
 		storeConnStr = fmt.Sprintf(


### PR DESCRIPTION
At present, wuzapi's data directory is derived from executable location.

If wuzapi is built, packaged, and installed , it can end up in a location like /usr/bin which isn't writeable for users.

With -datadir, users can opt for a different data directory.

For example:

wuzapi -datadir=/tmp/test-data