### PR TITLE
Set PlatformType to 'DESKTOP'

### DIFF
--- a/wmiau.go
+++ b/wmiau.go
@@ -407,7 +407,7 @@ func (s *server) startClient(userID string, textjid string, token string, subscr
 	// Now we can use the client with the manager
 	clientManager.SetWhatsmeowClient(userID, client)
 
-	store.DeviceProps.PlatformType = waCompanionReg.DeviceProps_UNKNOWN.Enum()
+	store.DeviceProps.PlatformType = waCompanionReg.DeviceProps_DESKTOP.Enum()
 	store.DeviceProps.Os = osName
 
 	mycli := MyClient{client, 1, userID, token, subscriptions, s.db, s}


### PR DESCRIPTION
**Issue**:
Due to the value `PlatformType = DeviceProps_UNKNOWN` in the WhatsApp mobile application, the device is displayed with a question mark icon and the name “Other device” even despite the `SESSION_DEVICE_NAME` environment variable or the `-osname` launch parameter.

Changing the `PlatformType` parameter to `DeviceProps_DESKTOP` solves the problem.