### PR TITLE
Adding Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,10 @@ go build .
 
 ## Homebrew installation
 
-There's a [Homebrew](https://brew.sh) recipe over at [github.com/xenodium/homebrew-wuzapi](https://github.com/xenodium/homebrew-wuzapi).
-
-To install `wuzapi`, use:
+To install `wuzapi` via [Homebrew](https://brew.sh) use:
 
 ```sh
-brew install xenodium/wuzapi/wuzapi
+brew install asternic/wuzapi/wuzapi
 ```
 
 ## Run


### PR DESCRIPTION
Edit: See the new recipe location at [github.com/asternic/homebrew-wuzapi](https://github.com/asternic/homebrew-wuzapi)

I've created a [Homebrew](https://brew.sh) recipe over at [github.com/xenodium/homebrew-wuzapi](https://github.com/xenodium/homebrew-wuzapi).

This enables Homebrew users (very popular on macOS), to easily install `wuzapi` with:

```sh
brew install xenodium/wuzapi/wuzapi
```

This PR adds Homebrew install instructions to the README.

I'm happy to transfer ownership of the Homebrew recipe to you if you prefer (needs to be in a repository named `homebrew-wuzapi`). Lemme know.