### PR TITLE
feat(poll): decrypt poll votes and resolve selected options to plaintext

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -123,11 +123,3 @@ func (cm *ClientManager) GetPollOptions(userID, msgID string) []string {
 	}
 	return nil
 }
-
-// DeletePollOptionsForUser drops all cached poll options for a user when
-// their session disconnects or is removed.
-func (cm *ClientManager) DeletePollOptionsForUser(userID string) {
-	cm.Lock()
-	defer cm.Unlock()
-	delete(cm.pollOptions, userID)
-}

--- a/clients.go
+++ b/clients.go
@@ -12,6 +12,13 @@ type ClientManager struct {
 	whatsmeowClients map[string]*whatsmeow.Client
 	httpClients      map[string]*resty.Client
 	myClients        map[string]*MyClient
+	// pollOptions stores the plaintext options sent for each poll, keyed on
+	// userID then on the poll's message ID. This lets the event handler
+	// SHA-256-match incoming vote hashes back to the original option text
+	// before emitting the webhook payload. Entries are best-effort and
+	// in-memory only — if wuzapi restarts between send and vote, plaintext
+	// resolution is skipped and the webhook falls back to hashes only.
+	pollOptions map[string]map[string][]string
 }
 
 func NewClientManager() *ClientManager {
@@ -19,6 +26,7 @@ func NewClientManager() *ClientManager {
 		whatsmeowClients: make(map[string]*whatsmeow.Client),
 		httpClients:      make(map[string]*resty.Client),
 		myClients:        make(map[string]*MyClient),
+		pollOptions:      make(map[string]map[string][]string),
 	}
 }
 
@@ -70,10 +78,15 @@ func (cm *ClientManager) GetMyClient(userID string) *MyClient {
 	return cm.myClients[userID]
 }
 
+// DeleteMyClient removes a user's MyClient entry and clears any cached
+// poll options associated with that user (best-effort; callers that only
+// want to detach the MyClient should call clientManager.myClients delete
+// directly, but no such caller exists today).
 func (cm *ClientManager) DeleteMyClient(userID string) {
 	cm.Lock()
 	defer cm.Unlock()
 	delete(cm.myClients, userID)
+	delete(cm.pollOptions, userID)
 }
 
 // UpdateMyClientSubscriptions updates the event subscriptions of a client without reconnecting
@@ -83,4 +96,38 @@ func (cm *ClientManager) UpdateMyClientSubscriptions(userID string, subscription
 	if client, exists := cm.myClients[userID]; exists {
 		client.subscriptions = subscriptions
 	}
+}
+
+// SetPollOptions remembers the plaintext options of a poll we just sent so
+// that incoming votes (which arrive as SHA-256 hashes of the option text)
+// can be resolved back to readable strings.
+func (cm *ClientManager) SetPollOptions(userID, msgID string, options []string) {
+	cm.Lock()
+	defer cm.Unlock()
+	if cm.pollOptions[userID] == nil {
+		cm.pollOptions[userID] = make(map[string][]string)
+	}
+	stored := make([]string, len(options))
+	copy(stored, options)
+	cm.pollOptions[userID][msgID] = stored
+}
+
+// GetPollOptions returns the plaintext options associated with a poll
+// message, or nil if none were recorded (e.g. wuzapi restarted after the
+// poll was sent).
+func (cm *ClientManager) GetPollOptions(userID, msgID string) []string {
+	cm.RLock()
+	defer cm.RUnlock()
+	if byUser := cm.pollOptions[userID]; byUser != nil {
+		return byUser[msgID]
+	}
+	return nil
+}
+
+// DeletePollOptionsForUser drops all cached poll options for a user when
+// their session disconnects or is removed.
+func (cm *ClientManager) DeletePollOptionsForUser(userID string) {
+	cm.Lock()
+	defer cm.Unlock()
+	delete(cm.pollOptions, userID)
 }

--- a/handlers.go
+++ b/handlers.go
@@ -2755,6 +2755,10 @@ func (s *server) SendPoll() http.HandlerFunc {
 			return
 		}
 
+		// Remember the plaintext options so incoming vote webhooks can
+		// resolve the hashed selections back to readable strings.
+		clientManager.SetPollOptions(txtid, msgid, req.Options)
+
 		// Publish sent message event to RabbitMQ
 		token := r.Context().Value("userinfo").(Values).Get("Token")
 		userID := r.Context().Value("userinfo").(Values).Get("Id")

--- a/wmiau.go
+++ b/wmiau.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
@@ -862,6 +864,49 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 		}
 
 		log.Info().Str("id", evt.Info.ID).Str("source", evt.Info.SourceString()).Str("parts", strings.Join(metaParts, ", ")).Msg("Message Received")
+
+		// If this is a poll vote, decrypt the E2E-encrypted payload so the
+		// webhook can expose which options were selected. Votes arrive as
+		// SHA-256 hashes of the option text; we match those back to the
+		// plaintext options remembered at send time (see SendPoll in
+		// handlers.go). If the session was restarted between send and vote
+		// we cannot resolve plaintext; hashes are still emitted so the
+		// consumer can perform matching itself if it has stored options.
+		if evt.Message.GetPollUpdateMessage() != nil {
+			pollMsgID := evt.Message.GetPollUpdateMessage().GetPollCreationMessageKey().GetID()
+
+			pollVote, perr := mycli.WAClient.DecryptPollVote(context.Background(), evt)
+			if perr != nil {
+				log.Warn().Err(perr).Str("pollMsgID", pollMsgID).Msg("DecryptPollVote failed")
+			}
+
+			if perr == nil && pollVote != nil {
+				hashes := pollVote.GetSelectedOptions()
+				hashB64 := make([]string, 0, len(hashes))
+				for _, h := range hashes {
+					hashB64 = append(hashB64, base64.StdEncoding.EncodeToString(h))
+				}
+
+				selected := []string{}
+				if stored := clientManager.GetPollOptions(mycli.userID, pollMsgID); len(stored) > 0 {
+					for _, h := range hashes {
+						for _, opt := range stored {
+							sum := sha256.Sum256([]byte(opt))
+							if bytes.Equal(sum[:], h) {
+								selected = append(selected, opt)
+								break
+							}
+						}
+					}
+				}
+
+				postmap["pollVote"] = map[string]interface{}{
+					"pollCreationMsgID": pollMsgID,
+					"selectedOptions":   selected,
+					"selectedHashesB64": hashB64,
+				}
+			}
+		}
 
 		if !*skipMedia {
 

--- a/wmiau.go
+++ b/wmiau.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"crypto/tls"
@@ -887,15 +886,16 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 					hashB64 = append(hashB64, base64.StdEncoding.EncodeToString(h))
 				}
 
-				selected := []string{}
+				selected := make([]string, 0, len(hashes))
 				if stored := clientManager.GetPollOptions(mycli.userID, pollMsgID); len(stored) > 0 {
+					optionsByHash := make(map[string]string, len(stored))
+					for _, opt := range stored {
+						sum := sha256.Sum256([]byte(opt))
+						optionsByHash[string(sum[:])] = opt
+					}
 					for _, h := range hashes {
-						for _, opt := range stored {
-							sum := sha256.Sum256([]byte(opt))
-							if bytes.Equal(sum[:], h) {
-								selected = append(selected, opt)
-								break
-							}
+						if opt, found := optionsByHash[string(h)]; found {
+							selected = append(selected, opt)
 						}
 					}
 				}


### PR DESCRIPTION
## Summary

Poll vote webhooks currently expose only the encrypted `PollUpdateMessage`, which is not directly useful to downstream consumers: the "selected options" inside are SHA-256 hashes of the original option text, so matching them requires the consumer to independently retain the options it originally sent.

This PR teaches wuzapi to do that resolution itself:

1. When `/chat/send/poll` is called, the plaintext `Options` list is cached in-memory keyed by `(userID, pollMsgID)`.
2. When a `PollUpdateMessage` event arrives in the event handler, whatsmeow's `DecryptPollVote` is invoked to recover the selected option hashes.
3. Each hash is SHA-256-matched back against the remembered plaintext options.
4. The webhook payload gains a new top-level `pollVote` object:

   ```json
   "pollVote": {
     "pollCreationMsgID": "3EB0...",
     "selectedOptions": ["Done"],
     "selectedHashesB64": ["OS4m...=="]
   }
   ```

## Behaviour

- Cache is in-memory only and best-effort — if wuzapi restarts between send and vote, `selectedOptions` is empty but `selectedHashesB64` is still emitted so the consumer can match on its own.
- Cache is cleared when a client is deleted (`DeleteMyClient`).
- Existing webhook fields are untouched; this is purely additive.

## Why this is useful

Without plaintext resolution, every downstream system has to:
- store every outgoing poll's options on its side,
- re-hash them on vote arrival,
- match by bytes.

That's a lot of boilerplate for something wuzapi is already in the best position to do (it sent the poll and therefore already has the options in-process).

## Testing

Manually verified end-to-end with a reminder-style poll (`Done` / `Snooze 30m` / `Skip today`): webhook correctly emitted `selectedOptions: ["Done"]` when the user tapped Done on the phone.
