### PR TITLE
Add GitHub Actions workflow to update contributors

### DIFF
--- a/.github/workflows/updatecontrib.yml
+++ b/.github/workflows/updatecontrib.yml
@@ -1,0 +1,48 @@
+name: Update Readme Contributors
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-contributors:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install all-contributors CLI
+        run: npm install -g all-contributors-cli
+
+      - name: Generate contributors section
+        run: |
+          npx all-contributors-cli generate
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Pull Request
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'docs(README): update contributors'
+          title: 'docs: Update contributors list'
+          body: 'Automated update of contributors list'
+          labels: |
+            automated-pr
+            documentation
+          branch: update/contributors-list


### PR DESCRIPTION
This workflow automates the update of the contributors section in the README file using the all-contributors CLI.