### PR TITLE
feat(group): add join-request approval endpoints

### DIFF
--- a/API.md
+++ b/API.md
@@ -1334,6 +1334,89 @@ Response:
 }
 ```
 
+---
+
+## List pending join requests
+
+Lists participants who have requested to join the group. Requires join approval mode to be enabled on the group and the session to be a group admin.
+
+endpoint: _/group/requestparticipants_
+
+method: **GET**
+
+```
+curl -s -X GET -H 'Token: 1234ABCD' 'http://localhost:8080/group/requestparticipants?groupJID=120362023605733675@g.us'
+```
+
+Response:
+
+```json
+{
+  "code": 200,
+  "data": [
+    {
+      "JID": "70072425046185@lid",
+      "RequestedAt": "2026-05-27T00:34:40-03:00"
+    }
+  ],
+  "success": true
+}
+```
+
+---
+
+## Approve or reject join requests
+
+Approves or rejects participants who requested to join the group. Use the `JID` values returned by `/group/requestparticipants` in the `Phone` array.
+
+endpoint: _/group/updaterequestparticipants_
+
+method: **POST**
+
+`Action` must be `"approve"` or `"reject"`.
+
+```
+curl -s -X POST -H 'Token: 1234ABCD' -H 'Content-Type: application/json' -d '{"GroupJID":"120362023605733675@g.us","Phone":["70072425046185@lid"],"Action":"approve"}' http://localhost:8080/group/updaterequestparticipants
+```
+
+Response:
+
+```json
+{
+  "code": 200,
+  "data": {
+    "Details": "Group request participants updated successfully"
+  },
+  "success": true
+}
+```
+
+---
+
+## Set group join approval mode
+
+Enables or disables the requirement that new members be approved by an admin before joining the group.
+
+endpoint: _/group/joinapprovalmode_
+
+method: **POST**
+
+```
+curl -s -X POST -H 'Token: 1234ABCD' -H 'Content-Type: application/json' -d '{"groupjid":"120362023605733675@g.us","mode":true}' http://localhost:8080/group/joinapprovalmode
+```
+
+Response:
+
+```json
+{
+  "code": 200,
+  "data": {
+    "Details": "Group join approval mode updated successfully"
+  },
+  "success": true
+}
+```
+
 # S3 Storage Integration for WuzAPI
 
 ## Overview

--- a/handlers_grouprequests.go
+++ b/handlers_grouprequests.go
@@ -12,7 +12,6 @@ package main
 // Kept in a dedicated file to minimise rebase conflicts against upstream.
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"

--- a/handlers_grouprequests.go
+++ b/handlers_grouprequests.go
@@ -191,7 +191,7 @@ func (s *server) SetGroupJoinApprovalMode() http.HandlerFunc {
 			return
 		}
 
-		err = clientManager.GetWhatsmeowClient(txtid).SetGroupJoinApprovalMode(context.Background(), group, t.Mode)
+		err = client.SetGroupJoinApprovalMode(r.Context(), group, t.Mode)
 
 		if err != nil {
 			log.Error().Str("error", fmt.Sprintf("%v", err)).Msg("failed to set group join approval mode")

--- a/handlers_grouprequests.go
+++ b/handlers_grouprequests.go
@@ -136,7 +136,7 @@ func (s *server) UpdateGroupRequestParticipants() http.HandlerFunc {
 			return
 		}
 
-		_, err = clientManager.GetWhatsmeowClient(txtid).UpdateGroupRequestParticipants(context.Background(), group, phoneParsed, action)
+		_, err = client.UpdateGroupRequestParticipants(r.Context(), group, phoneParsed, action)
 
 		if err != nil {
 			log.Error().Str("error", fmt.Sprintf("%v", err)).Msg("failed to update group request participants")

--- a/handlers_grouprequests.go
+++ b/handlers_grouprequests.go
@@ -171,7 +171,8 @@ func (s *server) SetGroupJoinApprovalMode() http.HandlerFunc {
 
 		txtid := r.Context().Value("userinfo").(Values).Get("Id")
 
-		if clientManager.GetWhatsmeowClient(txtid) == nil {
+		client := clientManager.GetWhatsmeowClient(txtid)
+		if client == nil {
 			s.Respond(w, r, http.StatusInternalServerError, errors.New("no session"))
 			return
 		}

--- a/handlers_grouprequests.go
+++ b/handlers_grouprequests.go
@@ -1,0 +1,211 @@
+package main
+
+// Group join-request handlers (membership approval queue).
+//
+// WhatsApp groups can require admin approval for new members. whatsmeow exposes
+// the underlying calls but upstream wuzapi did not surface them, so these three
+// handlers wrap them:
+//   GET  /group/requestparticipants        -> list pending join requests
+//   POST /group/updaterequestparticipants  -> approve/reject pending requests
+//   POST /group/joinapprovalmode           -> toggle the approval requirement
+//
+// Kept in a dedicated file to minimise rebase conflicts against upstream.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+	"go.mau.fi/whatsmeow"
+	"go.mau.fi/whatsmeow/types"
+)
+
+// GetGroupRequestParticipants lists the participants who have requested to join
+// the group. Only meaningful when join approval mode is enabled for the group.
+func (s *server) GetGroupRequestParticipants() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		txtid := r.Context().Value("userinfo").(Values).Get("Id")
+
+		if clientManager.GetWhatsmeowClient(txtid) == nil {
+			s.Respond(w, r, http.StatusInternalServerError, errors.New("no session"))
+			return
+		}
+
+		// Get GroupJID from query parameter
+		groupJID := r.URL.Query().Get("groupJID")
+		if groupJID == "" {
+			s.Respond(w, r, http.StatusBadRequest, errors.New("missing groupJID parameter"))
+			return
+		}
+
+		group, ok := parseJID(groupJID)
+		if !ok {
+			s.Respond(w, r, http.StatusBadRequest, errors.New("could not parse Group JID"))
+			return
+		}
+
+		resp, err := clientManager.GetWhatsmeowClient(txtid).GetGroupRequestParticipants(context.Background(), group)
+
+		if err != nil {
+			msg := fmt.Sprintf("Failed to get group request participants: %v", err)
+			log.Error().Msg(msg)
+			s.Respond(w, r, http.StatusInternalServerError, errors.New(msg))
+			return
+		}
+
+		responseJson, err := json.Marshal(resp)
+
+		if err != nil {
+			s.Respond(w, r, http.StatusInternalServerError, err)
+		} else {
+			s.Respond(w, r, http.StatusOK, string(responseJson))
+		}
+
+		return
+	}
+}
+
+// UpdateGroupRequestParticipants approves or rejects pending requests to join
+// the group. Action must be "approve" or "reject".
+func (s *server) UpdateGroupRequestParticipants() http.HandlerFunc {
+
+	type updateGroupRequestParticipantsStruct struct {
+		GroupJID string
+		Phone    []string
+		Action   string // approve, reject
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		txtid := r.Context().Value("userinfo").(Values).Get("Id")
+
+		if clientManager.GetWhatsmeowClient(txtid) == nil {
+			s.Respond(w, r, http.StatusInternalServerError, errors.New("no session"))
+			return
+		}
+
+		decoder := json.NewDecoder(r.Body)
+		var t updateGroupRequestParticipantsStruct
+		err := decoder.Decode(&t)
+		if err != nil {
+			s.Respond(w, r, http.StatusBadRequest, errors.New("could not decode Payload"))
+			return
+		}
+
+		group, ok := parseJID(t.GroupJID)
+		if !ok {
+			s.Respond(w, r, http.StatusBadRequest, errors.New("could not parse Group JID"))
+			return
+		}
+
+		if len(t.Phone) < 1 {
+			s.Respond(w, r, http.StatusBadRequest, errors.New("missing Phone in Payload"))
+			return
+		}
+
+		// parse phone numbers
+		phoneParsed := make([]types.JID, len(t.Phone))
+		for i, phone := range t.Phone {
+			phoneParsed[i], ok = parseJID(phone)
+			if !ok {
+				s.Respond(w, r, http.StatusBadRequest, errors.New("could not parse Phone"))
+				return
+			}
+		}
+
+		if t.Action == "" {
+			s.Respond(w, r, http.StatusBadRequest, errors.New("missing Action in Payload"))
+			return
+		}
+
+		// parse action
+		var action whatsmeow.ParticipantRequestChange
+		switch t.Action {
+		case "approve":
+			action = whatsmeow.ParticipantChangeApprove
+		case "reject":
+			action = whatsmeow.ParticipantChangeReject
+		default:
+			s.Respond(w, r, http.StatusBadRequest, errors.New("invalid Action in Payload (must be approve or reject)"))
+			return
+		}
+
+		_, err = clientManager.GetWhatsmeowClient(txtid).UpdateGroupRequestParticipants(context.Background(), group, phoneParsed, action)
+
+		if err != nil {
+			log.Error().Str("error", fmt.Sprintf("%v", err)).Msg("failed to update group request participants")
+			msg := fmt.Sprintf("failed to update group request participants: %v", err)
+			s.Respond(w, r, http.StatusInternalServerError, errors.New(msg))
+			return
+		}
+
+		response := map[string]interface{}{"Details": "Group request participants updated successfully"}
+		responseJson, err := json.Marshal(response)
+
+		if err != nil {
+			s.Respond(w, r, http.StatusInternalServerError, err)
+		} else {
+			s.Respond(w, r, http.StatusOK, string(responseJson))
+		}
+
+		return
+	}
+}
+
+// SetGroupJoinApprovalMode toggles whether new members must be approved by an
+// admin before joining the group.
+func (s *server) SetGroupJoinApprovalMode() http.HandlerFunc {
+
+	type setGroupJoinApprovalModeStruct struct {
+		GroupJID string `json:"groupjid"`
+		Mode     bool   `json:"mode"`
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		txtid := r.Context().Value("userinfo").(Values).Get("Id")
+
+		if clientManager.GetWhatsmeowClient(txtid) == nil {
+			s.Respond(w, r, http.StatusInternalServerError, errors.New("no session"))
+			return
+		}
+
+		decoder := json.NewDecoder(r.Body)
+		var t setGroupJoinApprovalModeStruct
+		err := decoder.Decode(&t)
+		if err != nil {
+			s.Respond(w, r, http.StatusBadRequest, errors.New("could not decode Payload"))
+			return
+		}
+
+		group, ok := parseJID(t.GroupJID)
+		if !ok {
+			s.Respond(w, r, http.StatusBadRequest, errors.New("could not parse Group JID"))
+			return
+		}
+
+		err = clientManager.GetWhatsmeowClient(txtid).SetGroupJoinApprovalMode(context.Background(), group, t.Mode)
+
+		if err != nil {
+			log.Error().Str("error", fmt.Sprintf("%v", err)).Msg("failed to set group join approval mode")
+			msg := fmt.Sprintf("failed to set group join approval mode: %v", err)
+			s.Respond(w, r, http.StatusInternalServerError, errors.New(msg))
+			return
+		}
+
+		response := map[string]interface{}{"Details": "Group join approval mode updated successfully"}
+		responseJson, err := json.Marshal(response)
+
+		if err != nil {
+			s.Respond(w, r, http.StatusInternalServerError, err)
+		} else {
+			s.Respond(w, r, http.StatusOK, string(responseJson))
+		}
+
+		return
+	}
+}

--- a/handlers_grouprequests.go
+++ b/handlers_grouprequests.go
@@ -30,7 +30,8 @@ func (s *server) GetGroupRequestParticipants() http.HandlerFunc {
 
 		txtid := r.Context().Value("userinfo").(Values).Get("Id")
 
-		if clientManager.GetWhatsmeowClient(txtid) == nil {
+		client := clientManager.GetWhatsmeowClient(txtid)
+		if client == nil {
 			s.Respond(w, r, http.StatusInternalServerError, errors.New("no session"))
 			return
 		}
@@ -48,7 +49,7 @@ func (s *server) GetGroupRequestParticipants() http.HandlerFunc {
 			return
 		}
 
-		resp, err := clientManager.GetWhatsmeowClient(txtid).GetGroupRequestParticipants(context.Background(), group)
+		resp, err := client.GetGroupRequestParticipants(r.Context(), group)
 
 		if err != nil {
 			msg := fmt.Sprintf("Failed to get group request participants: %v", err)

--- a/handlers_grouprequests.go
+++ b/handlers_grouprequests.go
@@ -84,7 +84,8 @@ func (s *server) UpdateGroupRequestParticipants() http.HandlerFunc {
 
 		txtid := r.Context().Value("userinfo").(Values).Get("Id")
 
-		if clientManager.GetWhatsmeowClient(txtid) == nil {
+		client := clientManager.GetWhatsmeowClient(txtid)
+		if client == nil {
 			s.Respond(w, r, http.StatusInternalServerError, errors.New("no session"))
 			return
 		}

--- a/routes.go
+++ b/routes.go
@@ -158,6 +158,9 @@ func (s *server) routes() {
 	s.router.Handle("/group/join", c.Then(s.GroupJoin())).Methods("POST")
 	s.router.Handle("/group/inviteinfo", c.Then(s.GetGroupInviteInfo())).Methods("POST")
 	s.router.Handle("/group/updateparticipants", c.Then(s.UpdateGroupParticipants())).Methods("POST")
+	s.router.Handle("/group/requestparticipants", c.Then(s.GetGroupRequestParticipants())).Methods("GET")
+	s.router.Handle("/group/updaterequestparticipants", c.Then(s.UpdateGroupRequestParticipants())).Methods("POST")
+	s.router.Handle("/group/joinapprovalmode", c.Then(s.SetGroupJoinApprovalMode())).Methods("POST")
 
 	s.router.Handle("/newsletter/list", c.Then(s.ListNewsletter())).Methods("GET")
 

--- a/static/api/spec.yml
+++ b/static/api/spec.yml
@@ -2027,6 +2027,70 @@ paths:
             application/json:
               schema:
                 example: { "code": 200, "data": { "Details": "Participants updated successfully" }, "success": true }
+  /group/requestparticipants:
+    get:
+      tags:
+        - Group
+      summary: List pending join requests
+      description: Lists participants who have requested to join the group. Requires join approval mode to be enabled and the session to be an admin of the group.
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - in: query
+          name: groupJID
+          schema:
+            type: string
+          required: true
+          description: The JID of the group
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                example: { "code": 200, "data": [ { "JID": "70072425046185@lid", "RequestedAt": "2026-05-27T00:34:40-03:00" } ], "success": true }
+  /group/updaterequestparticipants:
+    post:
+      tags:
+        - Group
+      summary: Approve or reject pending join requests
+      description: Approves or rejects participants who requested to join the group.
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/definitions/UpdateGroupRequestParticipants'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                example: { "code": 200, "data": { "Details": "Group request participants updated successfully" }, "success": true }
+  /group/joinapprovalmode:
+    post:
+      tags:
+        - Group
+      summary: Toggle group join approval mode
+      description: Enables or disables the requirement that new members be approved by an admin before joining the group.
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/definitions/SetGroupJoinApprovalMode'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                example: { "code": 200, "data": { "Details": "Group join approval mode updated successfully" }, "success": true }
 
 definitions:
   ContextInfo:
@@ -2992,6 +3056,44 @@ definitions:
           type: string
           description: List of participant JIDs (e.g., 5491112345678@s.whatsapp.net or 5491112345678)
         example: [ "5491112345678", "5491123456789@s.whatsapp.net" ]
+
+  UpdateGroupRequestParticipants:
+    type: object
+    required:
+      - GroupJID
+      - Action
+      - Phone
+    properties:
+      GroupJID:
+        type: string
+        description: The JID of the group
+        example: 120363312246943103@g.us
+      Action:
+        type: string
+        description: Action to perform ("approve" to accept join requests, "reject" to decline them)
+        enum: [approve, reject]
+        example: approve
+      Phone:
+        type: array
+        items:
+          type: string
+          description: List of requesting participant JIDs as returned by /group/requestparticipants (e.g. 70072425046185@lid)
+        example: [ "70072425046185@lid" ]
+
+  SetGroupJoinApprovalMode:
+    type: object
+    required:
+      - groupjid
+      - mode
+    properties:
+      groupjid:
+        type: string
+        description: The JID of the group
+        example: 120363312246943103@g.us
+      mode:
+        type: boolean
+        description: true to require admin approval for new members, false to disable it
+        example: true
 
   CreateGroup:
     type: object


### PR DESCRIPTION
## What

Adds three group endpoints for the **membership approval queue** that whatsmeow already supports but wuzapi did not expose:

| Method | Endpoint | Purpose |
|---|---|---|
| `GET` | `/group/requestparticipants` | List participants who requested to join |
| `POST` | `/group/updaterequestparticipants` | Approve / reject pending requests (`Action: approve\|reject`) |
| `POST` | `/group/joinapprovalmode` | Toggle whether new members need admin approval (`mode: bool`) |

## Why

When a group has "approve new members" enabled, there was no way via the API to see or act on the pending queue — the only workaround was to moderate from the phone. The underlying whatsmeow calls (`GetGroupRequestParticipants`, `UpdateGroupRequestParticipants`, `SetGroupJoinApprovalMode`) were already available.

## Implementation

- Handlers live in a dedicated `handlers_grouprequests.go`, mirroring the style of the existing `UpdateGroupParticipants` handler (JID parsing, session check, response envelope).
- Three routes registered in `routes.go` next to `/group/updateparticipants`.
- Docs added to both `API.md` and `static/api/spec.yml`.

## Testing

Built and run against a live session. Verified end to end on a real group where the bot is admin:

1. `GET /group/requestparticipants` → returned the pending request `{"JID":"…@lid","RequestedAt":"…"}`
2. `POST /group/updaterequestparticipants` with `Action: approve` → `200`, the participant joined the group
3. `GET /group/requestparticipants` again → empty queue

Errors propagate cleanly (e.g. a non-admin session gets `info query returned status 403: forbidden` in the `error` field).