### PR TITLE
security: use crypto/rand for auto-generated secrets; stop logging user token

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -6382,7 +6382,7 @@ func (s *server) GetHistory() http.HandlerFunc {
 		if historyLimit == 0 {
 			// Before returning error, try refreshing the cache in case the DB was updated
 			token := r.Context().Value("userinfo").(Values).Get("Token")
-			log.Info().Str("userId", txtid).Str("token", token).Msg("History is 0, invalidating cache and trying fresh DB lookup")
+			log.Info().Str("userId", txtid).Msg("History is 0, invalidating cache and trying fresh DB lookup")
 			userinfocache.Delete(token)
 
 			// Re-fetch from database

--- a/main.go
+++ b/main.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
 	"flag"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"net"
 	"net/http"
 	"os"
@@ -156,6 +157,24 @@ func isPrivateOrLoopback(ip net.IP) bool {
 	return false
 }
 
+// secureToken returns a cryptographically secure random alphanumeric string of
+// length n, generated with crypto/rand. It replaces the previous math/rand-based
+// generation used for the auto-generated admin token and global encryption/HMAC
+// keys, whose output is predictable and therefore unsuitable for secrets.
+func secureToken(n int) (string, error) {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	max := big.NewInt(int64(len(charset)))
+	b := make([]byte, n)
+	for i := range b {
+		idx, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			return "", err
+		}
+		b[i] = charset[idx.Int64()]
+	}
+	return string(b), nil
+}
+
 func main() {
 	for _, cidr := range []string{
 		"127.0.0.0/8",    // IPv4 loopback
@@ -297,13 +316,12 @@ func main() {
 		if v := os.Getenv("WUZAPI_ADMIN_TOKEN"); v != "" {
 			*adminToken = v
 		} else {
-			// Generate a random token if none provided
-			const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-			b := make([]byte, 32)
-			for i := range b {
-				b[i] = charset[rand.Intn(len(charset))]
+			// Generate a cryptographically secure random token if none provided
+			tok, err := secureToken(32)
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to generate a secure admin token")
 			}
-			*adminToken = string(b)
+			*adminToken = tok
 			log.Warn().Str("admin_token", *adminToken).Msg("No admin token provided, generated a random one")
 		}
 	}
@@ -313,13 +331,12 @@ func main() {
 			*globalEncryptionKey = v
 			log.Info().Msg("Encryption key loaded from environment variable")
 		} else {
-			// Generate a random key if none provided
-			const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-			b := make([]byte, 32)
-			for i := range b {
-				b[i] = charset[rand.Intn(len(charset))]
+			// Generate a cryptographically secure random key if none provided
+			key, err := secureToken(32)
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to generate a secure encryption key")
 			}
-			*globalEncryptionKey = string(b)
+			*globalEncryptionKey = key
 			log.Warn().Str("global_encryption_key", *globalEncryptionKey).Msg("No WUZAPI_GLOBAL_ENCRYPTION_KEY provided, generated a random one. " +
 				"SAVE THIS KEY TO YOUR .ENV FILE OR ALL ENCRYPTED DATA WILL BE LOST ON RESTART!")
 		}
@@ -341,13 +358,12 @@ func main() {
 			*globalHMACKey = v
 			log.Info().Msg("Global HMAC key configured from environment variable")
 		} else {
-			// Generate a random key if none provided
-			const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-			b := make([]byte, 32)
-			for i := range b {
-				b[i] = charset[rand.Intn(len(charset))]
+			// Generate a cryptographically secure random key if none provided
+			key, err := secureToken(32)
+			if err != nil {
+				log.Fatal().Err(err).Msg("Failed to generate a secure HMAC key")
 			}
-			*globalHMACKey = string(b)
+			*globalHMACKey = key
 			log.Warn().Str("global_hmac_key", *globalHMACKey).Msg("No WUZAPI_GLOBAL_HMAC_KEY provided, generated a random one")
 		}
 

--- a/main_secrets_test.go
+++ b/main_secrets_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSecureToken verifies the crypto/rand-backed generator used for the
+// auto-generated admin token and global encryption/HMAC keys: correct length,
+// alphanumeric-only output, randomness across calls, and a sane zero-length
+// edge case.
+func TestSecureToken(t *testing.T) {
+	const n = 32
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+	tok, err := secureToken(n)
+	if err != nil {
+		t.Fatalf("secureToken returned error: %v", err)
+	}
+	if len(tok) != n {
+		t.Errorf("length = %d, want %d", len(tok), n)
+	}
+	for i, c := range tok {
+		if !strings.ContainsRune(charset, c) {
+			t.Errorf("char %q at index %d is outside the allowed charset", c, i)
+		}
+	}
+
+	// Two independent calls must differ — a sanity check that the output is
+	// actually random and not constant. Collision probability ~62^-32.
+	other, err := secureToken(n)
+	if err != nil {
+		t.Fatalf("secureToken returned error: %v", err)
+	}
+	if tok == other {
+		t.Errorf("two secureToken(%d) calls returned identical values — not random", n)
+	}
+
+	// Zero length is a valid edge case: empty string, no error.
+	if empty, err := secureToken(0); err != nil || empty != "" {
+		t.Errorf("secureToken(0) = %q, %v; want \"\", nil", empty, err)
+	}
+}


### PR DESCRIPTION
## Summary

Two small, independent credential-handling hardening fixes.

## 1. Use `crypto/rand` for auto-generated secrets (`main.go`)

When `WUZAPI_ADMIN_TOKEN`, `WUZAPI_GLOBAL_ENCRYPTION_KEY`, or `WUZAPI_GLOBAL_HMAC_KEY` are not supplied, the server auto-generates them with `math/rand`:

```go
b[i] = charset[rand.Intn(len(charset))]
```

`math/rand` is a non-cryptographic PRNG — its output is predictable. For these values that is a real risk:
- a guessable **admin token** gates user create/delete → effectively an auth bypass;
- a guessable **encryption key** defeats the AES protection of per-user HMAC keys at rest.

This replaces the three generation sites with a new `secureToken` helper backed by `crypto/rand` (`rand.Int`, so no modulo bias), preserving the existing 32-char alphanumeric format. A generation failure is fatal — a host with no entropy must not boot with a weak secret.

## 2. Stop logging the user auth token (`handlers.go`)

`GetHistory` logged the caller's plaintext token at INFO:

```go
log.Info().Str("userId", txtid).Str("token", token).Msg("History is 0, ...")
```

Anyone with access to application logs could harvest active tokens. The field is removed; `userId` remains for debugging. (The known, intentional admin-token-on-startup WARN log is unrelated and left as-is.)

## Testing
- `go build ./...` ✅
- `go vet ./...` ✅