### PR TITLE
fix: copy-on-write in updateUserInfo to avoid shared-map data race

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -235,8 +235,19 @@ func getOpenGraphData(ctx context.Context, urlStr string, userID string) (title,
 // Update entry in User map
 func updateUserInfo(values interface{}, field string, value string) interface{} {
 	log.Debug().Str("field", field).Str("value", value).Msg("User info updated")
-	values.(Values).m[field] = value
-	return values
+	// Copy-on-write: the map inside Values is shared — it lives in
+	// userinfocache and is handed to request goroutines via the request
+	// context. Mutating it in place races with concurrent readers (Values.Get)
+	// and can crash the process with "concurrent map read and map write".
+	// Build a fresh map and return a new Values; callers persist it via
+	// userinfocache.Set.
+	old := values.(Values)
+	m := make(map[string]string, len(old.m)+1)
+	for k, v := range old.m {
+		m[k] = v
+	}
+	m[field] = value
+	return Values{m: m}
 }
 
 // webhook for regular messages

--- a/helpers.go
+++ b/helpers.go
@@ -240,8 +240,9 @@ func updateUserInfo(values interface{}, field string, value string) interface{} 
 	// context. Mutating it in place races with concurrent readers (Values.Get)
 	// and can crash the process with "concurrent map read and map write".
 	// Build a fresh map and return a new Values; callers persist it via
-	// userinfocache.Set.
-	old := values.(Values)
+	// userinfocache.Set. Use a comma-ok assertion so a nil or unexpected value
+	// can't panic — it falls back to the zero Values (nil map), handled below.
+	old, _ := values.(Values)
 	m := make(map[string]string, len(old.m)+1)
 	for k, v := range old.m {
 		m[k] = v

--- a/userinfo_cache_test.go
+++ b/userinfo_cache_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+// TestUpdateUserInfoCopyOnWrite proves updateUserInfo does not mutate the
+// shared map. The map inside Values lives in userinfocache and is handed to
+// request goroutines via the request context, so an in-place write races with
+// concurrent readers. This assertion is deterministic (no -race needed): the
+// previous implementation mutated `base` and would fail here.
+func TestUpdateUserInfoCopyOnWrite(t *testing.T) {
+	base := Values{m: map[string]string{"Events": "Message", "Webhook": "https://example.test"}}
+
+	updated := updateUserInfo(base, "Events", "Message,ReadReceipt").(Values)
+
+	if got := base.Get("Events"); got != "Message" {
+		t.Errorf("shared Values was mutated in place: base Events=%q, want %q", got, "Message")
+	}
+	if got := updated.Get("Events"); got != "Message,ReadReceipt" {
+		t.Errorf("returned Values not updated: Events=%q, want %q", got, "Message,ReadReceipt")
+	}
+	if got := updated.Get("Webhook"); got != "https://example.test" {
+		t.Errorf("returned Values lost an unrelated field: Webhook=%q", got)
+	}
+}
+
+// TestUpdateUserInfoConcurrent exercises the data race directly. Run with
+// `go test -race`: the previous in-place mutation triggered "concurrent map
+// read and map write" when one goroutine updated while another read. The
+// copy-on-write version never writes to the shared map, so it is clean.
+func TestUpdateUserInfoConcurrent(t *testing.T) {
+	base := Values{m: map[string]string{"Events": "Message"}}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		go func(i int) {
+			defer wg.Done()
+			_ = updateUserInfo(base, "Events", fmt.Sprintf("v%d", i))
+		}(i)
+		go func() {
+			defer wg.Done()
+			_ = base.Get("Events")
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Problem

`updateUserInfo` mutates the map inside `Values` in place:

```go
func updateUserInfo(values interface{}, field string, value string) interface{} {
    values.(Values).m[field] = value
    return values
}
```

That map is **shared**: it is stored in `userinfocache` and handed to request goroutines through the request context (`r.Context().Value("userinfo")`). An in-place write therefore races with concurrent readers (`Values.Get`, called on every authenticated request by the access logger and throughout the handlers). Under load this is a classic `fatal error: concurrent map read and map write`, which crashes the whole process.

## Fix

Make `updateUserInfo` copy-on-write: build a fresh map, copy the existing entries, set the field, and return a new `Values`. The shared map is never written. All call sites already use the returned value and persist it via `userinfocache.Set`, so behaviour is unchanged.

## Testing
- `TestUpdateUserInfoCopyOnWrite` — deterministic: asserts the source `Values` is untouched and the returned one carries the update (plus unrelated fields). Verified **red→green** (fails against the in-place version, passes with the fix).
- `TestUpdateUserInfoConcurrent` — hammers `updateUserInfo` + `Get` from many goroutines; under `go test -race` the old version reports the data race, the new one is clean.
- `go build ./...` ✅ · `go vet ./...` ✅ · `go test ./...` ✅