### PR TITLE
refactor: remove write-only MyClient.subscriptions field (fixes a data race)

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -89,15 +89,6 @@ func (cm *ClientManager) DeleteMyClient(userID string) {
 	delete(cm.pollOptions, userID)
 }
 
-// UpdateMyClientSubscriptions updates the event subscriptions of a client without reconnecting
-func (cm *ClientManager) UpdateMyClientSubscriptions(userID string, subscriptions []string) {
-	cm.Lock()
-	defer cm.Unlock()
-	if client, exists := cm.myClients[userID]; exists {
-		client.subscriptions = subscriptions
-	}
-}
-
 // SetPollOptions remembers the plaintext options of a poll we just sent so
 // that incoming votes (which arrive as SHA-256 hashes of the option text)
 // can be resolved back to readable strings.

--- a/handlers.go
+++ b/handlers.go
@@ -276,7 +276,7 @@ func (s *server) Connect() http.HandlerFunc {
 
 		log.Info().Str("jid", jid).Msg("Attempt to connect")
 		killchannel[txtid] = make(chan bool, 1)
-		go s.startClient(txtid, jid, token, subscribedEvents)
+		go s.startClient(txtid, jid, token)
 
 		if t.Immediate == false {
 			log.Warn().Msg("Waiting 10 seconds")
@@ -467,9 +467,9 @@ func (s *server) UpdateWebhook() http.HandlerFunc {
 		if len(t.Events) > 0 {
 			_, err = s.db.Exec("UPDATE users SET webhook=$1, events=$2 WHERE id=$3", webhook, eventstring, txtid)
 
-			// Update MyClient if connected - integrated UpdateEvents functionality
+			// Event subscriptions are persisted to the users table and
+			// userinfocache above; the event handler re-reads them per event.
 			if len(validEvents) > 0 {
-				clientManager.UpdateMyClientSubscriptions(txtid, validEvents)
 				log.Info().Strs("events", validEvents).Str("user", txtid).Msg("Updated event subscriptions")
 			}
 		} else {
@@ -535,9 +535,9 @@ func (s *server) SetWebhook() http.HandlerFunc {
 			// Update both webhook and events
 			_, err = s.db.Exec("UPDATE users SET webhook=$1, events=$2 WHERE id=$3", webhook, eventstring, txtid)
 
-			// Update MyClient if connected - integrated UpdateEvents functionality
+			// Event subscriptions are persisted to the users table and
+			// userinfocache above; the event handler re-reads them per event.
 			if len(validEvents) > 0 {
-				clientManager.UpdateMyClientSubscriptions(txtid, validEvents)
 				log.Info().Strs("events", validEvents).Str("user", txtid).Msg("Updated event subscriptions")
 			}
 		} else {

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/patrickmn/go-cache"
+)
+
+// TestUpdateAndGetUserSubscriptionsFromCache proves that event-subscription
+// resolution works entirely through the userinfocache/DB path — which is why
+// the write-only MyClient.subscriptions field (removed in this change) was
+// unnecessary. updateAndGetUserSubscriptions is the only consumer of a user's
+// subscriptions and re-reads them per event, so dropping the dead field cannot
+// affect which events are delivered.
+func TestUpdateAndGetUserSubscriptionsFromCache(t *testing.T) {
+	s := makeTestServer(t)
+	const token = "sub-token"
+	const userID = "sub-user"
+
+	// Seed the cache exactly as the connect/webhook handlers do.
+	userinfocache.Set(token, Values{m: map[string]string{"Events": "Message,ReadReceipt"}}, cache.NoExpiration)
+	t.Cleanup(func() { userinfocache.Delete(token) })
+
+	mycli := &MyClient{userID: userID, token: token, db: s.db}
+	got, err := updateAndGetUserSubscriptions(mycli)
+	if err != nil {
+		t.Fatalf("updateAndGetUserSubscriptions returned error: %v", err)
+	}
+
+	want := []string{"Message", "ReadReceipt"}
+	if len(got) != len(want) {
+		t.Fatalf("subscriptions = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("subscriptions[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	// Unsupported event names must be filtered out.
+	userinfocache.Set(token, Values{m: map[string]string{"Events": "Message,NotAReal Event"}}, cache.NoExpiration)
+	got, err = updateAndGetUserSubscriptions(mycli)
+	if err != nil {
+		t.Fatalf("second call returned error: %v", err)
+	}
+	if len(got) != 1 || got[0] != "Message" {
+		t.Errorf("unsupported events not filtered: got %v, want [Message]", got)
+	}
+}

--- a/wmiau.go
+++ b/wmiau.go
@@ -439,7 +439,14 @@ func (s *server) startClient(userID string, textjid string, token string) {
 	store.DeviceProps.PlatformType = getPlatformTypeEnum(*platformType)
 	store.DeviceProps.Os = osName
 
-	mycli := MyClient{client, 1, userID, token, s.db, s}
+	mycli := MyClient{
+		WAClient:       client,
+		eventHandlerID: 1,
+		userID:         userID,
+		token:          token,
+		db:             s.db,
+		s:              s,
+	}
 	mycli.eventHandlerID = mycli.WAClient.AddEventHandler(mycli.myEventHandler)
 
 	// Store the MyClient in clientManager

--- a/wmiau.go
+++ b/wmiau.go
@@ -39,7 +39,6 @@ type MyClient struct {
 	eventHandlerID uint32
 	userID         string
 	token          string
-	subscriptions  []string
 	db             *sqlx.DB
 	s              *server
 }
@@ -150,9 +149,6 @@ func updateAndGetUserSubscriptions(mycli *MyClient) ([]string, error) {
 			}
 		}
 	}
-
-	// Update the client subscriptions
-	mycli.subscriptions = subscribedEvents
 
 	return subscribedEvents, nil
 }
@@ -308,7 +304,7 @@ func (s *server) connectOnStartup() {
 			eventstring := strings.Join(subscribedEvents, ",")
 			log.Info().Str("events", eventstring).Str("jid", jid).Msg("Attempt to connect")
 			killchannel[txtid] = make(chan bool, 1)
-			go s.startClient(txtid, jid, token, subscribedEvents)
+			go s.startClient(txtid, jid, token)
 
 			// Initialize S3 client if configured
 			go func(userID string) {
@@ -399,7 +395,7 @@ func getPlatformTypeEnum(platformType string) *waCompanionReg.DeviceProps_Platfo
 	}
 }
 
-func (s *server) startClient(userID string, textjid string, token string, subscriptions []string) {
+func (s *server) startClient(userID string, textjid string, token string) {
 	log.Info().Str("userid", userID).Str("jid", textjid).Msg("Starting websocket connection to Whatsapp")
 
 	// Connection retry constants
@@ -443,7 +439,7 @@ func (s *server) startClient(userID string, textjid string, token string, subscr
 	store.DeviceProps.PlatformType = getPlatformTypeEnum(*platformType)
 	store.DeviceProps.Os = osName
 
-	mycli := MyClient{client, 1, userID, token, subscriptions, s.db, s}
+	mycli := MyClient{client, 1, userID, token, s.db, s}
 	mycli.eventHandlerID = mycli.WAClient.AddEventHandler(mycli.myEventHandler)
 
 	// Store the MyClient in clientManager


### PR DESCRIPTION
## Problem

`MyClient.subscriptions` is written from two goroutines:

- `updateAndGetUserSubscriptions` (event-handler goroutine) — `mycli.subscriptions = subscribedEvents`, **no lock**;
- `UpdateMyClientSubscriptions` (HTTP request goroutines, via SetWebhook/UpdateWebhook).

…but it is **never read** anywhere in the codebase. So the two writes are a data race on a field that has no effect.

The real subscription state lives in the `users.events` column and `userinfocache`. `sendEventWithWebHook` calls `updateAndGetUserSubscriptions` on **every** event, which re-reads those and returns the list it then uses for the subscription check — it never consults the field.

## Fix

Remove the dead field and everything that only existed to feed it:
- the `subscriptions` field on `MyClient`;
- the unlocked write in `updateAndGetUserSubscriptions` (it still returns the computed list);
- the `UpdateMyClientSubscriptions` method and its two callers;
- the now-unused `subscriptions` parameter of `startClient`.

The webhook handlers already persist subscription changes to `users.events` and `userinfocache`, so behaviour is unchanged — only the race and the dead code are gone.

## Testing
- `TestUpdateAndGetUserSubscriptionsFromCache` — proves subscription resolution still works through the cache/DB path (the only consumer), including filtering of unsupported event names.
- `go build ./...` ✅ · `go vet ./...` ✅ · `go test ./...` ✅