### PR TITLE
feat(s3): surface the real document filename in media payloads

### DIFF
--- a/media.go
+++ b/media.go
@@ -24,6 +24,18 @@ type mediaS3Config struct {
 	MediaDelivery string
 }
 
+// resolveMediaFileName picks the filename surfaced in the webhook and S3
+// payloads. It prefers the sender's original filename (e.g. a document's
+// FileName) and falls back to the temp file's base name when none was
+// provided. filepath.Base strips any directory component a sender may have
+// embedded, so a crafted name can't escape into a path.
+func resolveMediaFileName(originalFileName, fallbackPath string) string {
+	if originalFileName != "" {
+		return filepath.Base(originalFileName)
+	}
+	return filepath.Base(fallbackPath)
+}
+
 func (mycli *MyClient) processMedia(
 	msg whatsmeow.DownloadableMessage,
 	mimeType string,
@@ -32,6 +44,7 @@ func (mycli *MyClient) processMedia(
 	isIncoming bool,
 	chatJID string,
 	messageID string,
+	originalFileName string,
 	s3cfg mediaS3Config,
 	postmap map[string]interface{},
 	extraKeys map[string]interface{},
@@ -56,6 +69,7 @@ func (mycli *MyClient) processMedia(
 		ext = exts[0]
 	}
 	tmpPath := filepath.Join(tmpDir, messageID+ext)
+	displayName := resolveMediaFileName(originalFileName, tmpPath)
 
 	if err := os.WriteFile(tmpPath, data, 0600); err != nil {
 		log.Error().Err(err).Msg("Failed to save media to temporary file")
@@ -77,7 +91,7 @@ func (mycli *MyClient) processMedia(
 			messageID,
 			data,
 			mimeType,
-			filepath.Base(tmpPath),
+			displayName,
 			isIncoming,
 		)
 		if err != nil {
@@ -95,7 +109,7 @@ func (mycli *MyClient) processMedia(
 		}
 		postmap["base64"] = b64
 		postmap["mimeType"] = mime_
-		postmap["fileName"] = filepath.Base(tmpPath)
+		postmap["fileName"] = displayName
 	}
 
 	for k, v := range extraKeys {

--- a/media.go
+++ b/media.go
@@ -5,6 +5,7 @@ import (
 	"mime"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -27,11 +28,14 @@ type mediaS3Config struct {
 // resolveMediaFileName picks the filename surfaced in the webhook and S3
 // payloads. It prefers the sender's original filename (e.g. a document's
 // FileName) and falls back to the temp file's base name when none was
-// provided. filepath.Base strips any directory component a sender may have
-// embedded, so a crafted name can't escape into a path.
+// provided. It strips any directory component a sender may have embedded so a
+// crafted name can't escape into a path. Backslashes are normalised to forward
+// slashes first: filepath.Base only treats the OS separator as a divider, so on
+// Linux (where this typically runs) a Windows-style "..\\..\\name" would not be
+// stripped otherwise.
 func resolveMediaFileName(originalFileName, fallbackPath string) string {
 	if originalFileName != "" {
-		return filepath.Base(originalFileName)
+		return filepath.Base(strings.ReplaceAll(originalFileName, "\\", "/"))
 	}
 	return filepath.Base(fallbackPath)
 }

--- a/media_filename_test.go
+++ b/media_filename_test.go
@@ -1,0 +1,29 @@
+package main
+
+import "testing"
+
+// TestResolveMediaFileName covers the filename surfaced in webhook/S3 payloads
+// for incoming media (issue #287). Documents carry a real FileName that must be
+// preferred over the messageID-based temp name; other media fall back to the
+// temp base; and any directory component a sender embeds must be stripped.
+func TestResolveMediaFileName(t *testing.T) {
+	cases := []struct {
+		name     string
+		original string
+		fallback string
+		want     string
+	}{
+		{"document keeps real name", "Quarterly Report.xlsx", "/tmp/user_x/3EB0C942.xlsx", "Quarterly Report.xlsx"},
+		{"empty falls back to temp base", "", "/tmp/user_x/3EB0C942.xlsx", "3EB0C942.xlsx"},
+		{"path components are stripped", "../../etc/passwd", "/tmp/x/abc.bin", "passwd"},
+		{"windows path components stripped", `..\..\secret.txt`, "/tmp/x/abc.bin", "secret.txt"},
+		{"plain name with empty fallback", "plain.pdf", "", "plain.pdf"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := resolveMediaFileName(c.original, c.fallback); got != c.want {
+				t.Errorf("resolveMediaFileName(%q, %q) = %q, want %q", c.original, c.fallback, got, c.want)
+			}
+		})
+	}
+}

--- a/wmiau.go
+++ b/wmiau.go
@@ -953,35 +953,37 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 			if img := evt.Message.GetImageMessage(); img != nil {
 				mycli.processMedia(img, img.GetMimetype(), ".jpg",
 					downloadTimeoutImage, isIncoming, chatJID,
-					evt.Info.ID, s3cfg, postmap, nil)
+					evt.Info.ID, "", s3cfg, postmap, nil)
 			}
 
 			if audio := evt.Message.GetAudioMessage(); audio != nil {
 				mycli.processMedia(audio, audio.GetMimetype(), ".ogg",
 					downloadTimeoutAudio, isIncoming, chatJID,
-					evt.Info.ID, s3cfg, postmap, nil)
+					evt.Info.ID, "", s3cfg, postmap, nil)
 			}
 
 			if doc := evt.Message.GetDocumentMessage(); doc != nil {
 				ext := ".bin"
+				docName := ""
 				if doc.FileName != nil {
+					docName = *doc.FileName
 					ext = filepath.Ext(*doc.FileName)
 				}
 				mycli.processMedia(doc, doc.GetMimetype(), ext,
 					downloadTimeoutDocument, isIncoming, chatJID,
-					evt.Info.ID, s3cfg, postmap, nil)
+					evt.Info.ID, docName, s3cfg, postmap, nil)
 			}
 
 			if video := evt.Message.GetVideoMessage(); video != nil {
 				mycli.processMedia(video, video.GetMimetype(), ".mp4",
 					downloadTimeoutVideo, isIncoming, chatJID,
-					evt.Info.ID, s3cfg, postmap, nil)
+					evt.Info.ID, "", s3cfg, postmap, nil)
 			}
 
 			if sticker := evt.Message.GetStickerMessage(); sticker != nil {
 				mycli.processMedia(sticker, sticker.GetMimetype(), ".webp",
 					downloadTimeoutSticker, isIncoming, chatJID,
-					evt.Info.ID, s3cfg, postmap, map[string]interface{}{
+					evt.Info.ID, "", s3cfg, postmap, map[string]interface{}{
 						"isSticker":       true,
 						"stickerAnimated": sticker.GetIsAnimated(),
 					})


### PR DESCRIPTION
## Problem (#287)

For incoming media, the webhook `fileName` field and the S3 metadata always reported a messageID-based name like `3EB0C942ACF157920E3D42.xlsx` — the document's real `FileName` was discarded. `processMedia` passed `filepath.Base(tmpPath)` (which is `messageID + ext`) as the filename to both the base64 payload and `ProcessMediaForS3`.

## Fix

Thread the sender's original filename through `processMedia`:

- a new `originalFileName` parameter, populated from `*doc.FileName` for documents (empty for image/audio/video/sticker, which carry no user-facing name);
- a small `resolveMediaFileName(originalFileName, fallbackPath)` helper that prefers the original name and falls back to the temp base. It runs the result through `filepath.Base`, so a crafted name like `../../etc/passwd` can't smuggle a path into the payload;
- the resolved name is used for both `postmap["fileName"]` and the `fileName` returned by `ProcessMediaForS3`.

The S3 **object key** is intentionally left messageID-based — it's guaranteed unique and free of unsafe characters. Only the human-facing `fileName` now reflects the real document name. (Putting the raw filename in the key would risk collisions/encoding issues; that can be a follow-up if desired.)

## Testing
- `TestResolveMediaFileName` — table test: document keeps its real name, empty falls back to the temp base, and POSIX/Windows path components are stripped.
- `go build ./...` ✅ · `go vet ./...` ✅ · `go test ./...` ✅