### PR TITLE
feat(user): set WhatsApp profile name via POST /user/profile/name (#281)

### DIFF
--- a/API.md
+++ b/API.md
@@ -697,6 +697,33 @@ Response:
 
 ---
 
+## Set Profile Name
+
+Sets the account's own WhatsApp profile (push) name — the display name other users see. Requires a connected session that has completed its initial app-state sync after pairing (otherwise the call returns 409 until the sync is done).
+
+Endpoint: _/user/profile/name_
+
+Method: **POST**
+
+```
+curl -s -X POST -H 'Token: 1234ABCD' -H 'Content-Type: application/json' --data '{"Name":"My Business"}' http://localhost:8080/user/profile/name
+```
+
+Response:
+
+```json
+{
+  "code": 200,
+  "data": {
+    "Details": "Profile name set",
+    "Name": "My Business"
+  },
+  "success": true
+}
+```
+
+---
+
 
 # Chat
 

--- a/handlers.go
+++ b/handlers.go
@@ -2572,6 +2572,61 @@ func (s *server) SetStatusMessage() http.HandlerFunc {
 	}
 }
 
+// SetProfileName sets the account's own WhatsApp profile (push) name. whatsmeow
+// exposes no direct Client setter for this; the push name is changed by sending
+// a "setting_pushName" app-state mutation, so we build that patch and send it.
+func (s *server) SetProfileName() http.HandlerFunc {
+
+	type nameStruct struct {
+		Name string
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		txtid := r.Context().Value("userinfo").(Values).Get("Id")
+
+		decoder := json.NewDecoder(r.Body)
+		var t nameStruct
+		if err := decoder.Decode(&t); err != nil {
+			s.Respond(w, r, http.StatusBadRequest, errors.New("could not decode Payload"))
+			return
+		}
+
+		t.Name = strings.TrimSpace(t.Name)
+		if t.Name == "" {
+			s.Respond(w, r, http.StatusBadRequest, errors.New("missing Name in Payload"))
+			return
+		}
+
+		client := clientManager.GetWhatsmeowClient(txtid)
+		if client == nil {
+			s.Respond(w, r, http.StatusInternalServerError, errors.New("no session"))
+			return
+		}
+
+		err := client.SendAppState(context.Background(), appstate.BuildSettingPushName(t.Name))
+		if err != nil {
+			// App state keys only exist after the initial post-pairing sync.
+			// Surface that as a clear client error rather than a generic 500.
+			if strings.Contains(err.Error(), "app state keys") {
+				s.Respond(w, r, http.StatusConflict, errors.New("profile name not settable yet: app state not synced — reconnect once after pairing and retry"))
+				return
+			}
+			s.Respond(w, r, http.StatusInternalServerError, fmt.Errorf("error setting profile name: %w", err))
+			return
+		}
+
+		log.Info().Str("userID", txtid).Str("name", t.Name).Msg("Profile push name updated")
+		response := map[string]interface{}{"Details": "Profile name set", "Name": t.Name}
+		responseJson, err := json.Marshal(response)
+		if err != nil {
+			s.Respond(w, r, http.StatusInternalServerError, err)
+		} else {
+			s.Respond(w, r, http.StatusOK, string(responseJson))
+		}
+	}
+}
+
 // Sends a regular text message
 func (s *server) SendMessage() http.HandlerFunc {
 	type textStruct struct {

--- a/handlers.go
+++ b/handlers.go
@@ -2604,7 +2604,7 @@ func (s *server) SetProfileName() http.HandlerFunc {
 			return
 		}
 
-		err := client.SendAppState(context.Background(), appstate.BuildSettingPushName(t.Name))
+		err := client.SendAppState(r.Context(), appstate.BuildSettingPushName(t.Name))
 		if err != nil {
 			// App state keys only exist after the initial post-pairing sync.
 			// Surface that as a clear client error rather than a generic 500.

--- a/profile_name_test.go
+++ b/profile_name_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestSetProfileNameValidation covers the request-validation and session-guard
+// paths of the #281 profile-name endpoint without a live WhatsApp session (the
+// actual SendAppState round-trip needs a paired client and can't be unit-tested
+// here). It mirrors how the authalice middleware injects "userinfo".
+func TestSetProfileNameValidation(t *testing.T) {
+	s := makeTestServer(t)
+	handler := s.SetProfileName()
+
+	call := func(body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/user/profile/name", strings.NewReader(body))
+		ctx := context.WithValue(req.Context(), "userinfo", Values{map[string]string{"Id": "profile-test-user"}})
+		req = req.WithContext(ctx)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		return rr
+	}
+
+	t.Run("empty name is rejected", func(t *testing.T) {
+		if rr := call(`{"Name":""}`); rr.Code != http.StatusBadRequest {
+			t.Errorf("empty name: got %d, want 400 (body=%s)", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("whitespace-only name is rejected", func(t *testing.T) {
+		if rr := call(`{"Name":"   "}`); rr.Code != http.StatusBadRequest {
+			t.Errorf("whitespace name: got %d, want 400", rr.Code)
+		}
+	})
+
+	t.Run("malformed JSON is rejected", func(t *testing.T) {
+		if rr := call(`{not json`); rr.Code != http.StatusBadRequest {
+			t.Errorf("bad json: got %d, want 400", rr.Code)
+		}
+	})
+
+	t.Run("valid name without a live session returns no-session error", func(t *testing.T) {
+		rr := call(`{"Name":"Alice"}`)
+		if rr.Code != http.StatusInternalServerError {
+			t.Errorf("no session: got %d, want 500 (body=%s)", rr.Code, rr.Body.String())
+		}
+		if !strings.Contains(rr.Body.String(), "session") {
+			t.Errorf("expected a session-related error, got body=%s", rr.Body.String())
+		}
+	})
+}

--- a/routes.go
+++ b/routes.go
@@ -133,6 +133,7 @@ func (s *server) routes() {
 	s.router.Handle("/user/contacts", c.Then(s.GetContacts())).Methods("GET")
 	s.router.Handle("/user/block", c.Then(s.BlockUser())).Methods("POST")
 	s.router.Handle("/user/unblock", c.Then(s.UnblockUser())).Methods("POST")
+	s.router.Handle("/user/profile/name", c.Then(s.SetProfileName())).Methods("POST")
 	s.router.Handle("/user/lid/{jid}", c.Then(s.GetUserLID())).Methods("GET")
 
 	s.router.Handle("/chat/presence", c.Then(s.ChatPresence())).Methods("POST")


### PR DESCRIPTION
## Summary (#281)

Adds an endpoint to set the account's own WhatsApp profile (push) name — requested in #281.

whatsmeow exposes no direct `Client` setter for this, but the `appstate` subpackage already provides `BuildSettingPushName`, and the push name is changed by sending a `setting_pushName` app-state mutation. The library decodes the same mutation on the receive side, so this is the supported mechanism, not a hack.

## Endpoint

`POST /user/profile/name` — body `{"Name": "..."}`, which runs:

```go
client.SendAppState(ctx, appstate.BuildSettingPushName(name))
```

- Non-empty (trimmed) `Name` required → `400` otherwise.
- Live session required → `500 no session` otherwise.
- App-state keys only exist after the initial post-pairing sync; that case (`no app state keys found`) is surfaced as **`409`** with an actionable message instead of a generic 500.

## Testing
- `TestSetProfileNameValidation`: empty / whitespace / malformed-JSON → 400; valid name without a session → no-session error.
- The actual WhatsApp round-trip (`SendAppState`) needs a paired, synced session and isn't unit-testable here; the call itself is documented `appstate` + `SendAppState` usage.
- `go build ./...` ✅ · `go vet ./...` ✅ · `go test ./...` ✅
- Docs added to `API.md`.

Fixes #281