### PR TITLE
fix: guard two reachable index panics (empty JID, short video data URL)

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -1614,7 +1614,7 @@ func (s *server) SendVideo() http.HandlerFunc {
 		var uploaded whatsmeow.UploadResponse
 		var filedata []byte
 
-		if t.Video[0:4] == "data" {
+		if len(t.Video) >= 4 && t.Video[0:4] == "data" {
 			var dataURL, err = dataurl.DecodeString(t.Video)
 			if err != nil {
 				s.Respond(w, r, http.StatusBadRequest, errors.New("could not decode base64 encoded data from payload"))

--- a/handlers.go
+++ b/handlers.go
@@ -1614,7 +1614,7 @@ func (s *server) SendVideo() http.HandlerFunc {
 		var uploaded whatsmeow.UploadResponse
 		var filedata []byte
 
-		if len(t.Video) >= 4 && t.Video[0:4] == "data" {
+		if strings.HasPrefix(t.Video, "data") {
 			var dataURL, err = dataurl.DecodeString(t.Video)
 			if err != nil {
 				s.Respond(w, r, http.StatusBadRequest, errors.New("could not decode base64 encoded data from payload"))

--- a/panic_guards_test.go
+++ b/panic_guards_test.go
@@ -1,0 +1,19 @@
+package main
+
+import "testing"
+
+// TestParseJIDEmptyString guards a real panic: parseJID indexed arg[0] before
+// checking length, so an empty string — reachable from handlers that don't
+// pre-validate, e.g. an empty GroupJID in SetGroupName/SetGroupTopic — panicked
+// with "index out of range [0] with length 0". Verified red→green.
+func TestParseJIDEmptyString(t *testing.T) {
+	if _, ok := parseJID(""); ok { // must not panic
+		t.Errorf(`parseJID("") returned ok=true, want false`)
+	}
+	if _, ok := parseJID("5491155554444"); !ok {
+		t.Errorf("parseJID of a bare number should still succeed")
+	}
+	if _, ok := parseJID("+5491155554444"); !ok {
+		t.Errorf("parseJID of a +-prefixed number should still succeed")
+	}
+}

--- a/wmiau.go
+++ b/wmiau.go
@@ -323,6 +323,9 @@ func (s *server) connectOnStartup() {
 }
 
 func parseJID(arg string) (types.JID, bool) {
+	if arg == "" {
+		return types.JID{}, false
+	}
 	if arg[0] == '+' {
 		arg = arg[1:]
 	}

--- a/wmiau.go
+++ b/wmiau.go
@@ -326,7 +326,7 @@ func parseJID(arg string) (types.JID, bool) {
 	if arg == "" {
 		return types.JID{}, false
 	}
-	if arg[0] == '+' {
+	if strings.HasPrefix(arg, "+") {
 		arg = arg[1:]
 	}
 	if !strings.ContainsRune(arg, '@') {


### PR DESCRIPTION
## Problem

Two reachable panics from request input:

1. **`parseJID("")` panics.** `parseJID` (wmiau.go) does `if arg[0] == '+'` before any length check, so an empty string panics with `index out of range [0] with length 0`. It's reachable from the group handlers that pass `t.GroupJID` straight to `parseJID` without an emptiness check (`SetGroupName`, `SetGroupTopic`, `SetGroupAnnounce`, `SetGroupLocked`, `RemoveGroupPhoto`, `SetDisappearingTimer`, `SetGroupPhoto`) — an authenticated request with `{"GroupJID":""}` crashes the request goroutine.

2. **`SendVideo` panics on a short `Video` field.** `if t.Video[0:4] == "data"` slices the first 4 bytes with no length check, so `{"Video":"ab"}` panics with `slice bounds out of range`. The sibling `SendImage` already guards this with `len(t.Image) >= 10 && ...`.

## Fix

- `parseJID`: return `(types.JID{}, false)` for an empty string up front.
- `SendVideo`: `len(t.Video) >= 4 && t.Video[0:4] == "data"`, matching `SendImage`.

## Testing
- `TestParseJIDEmptyString` — `parseJID("")` returns `ok=false` without panicking; bare and `+`-prefixed numbers still parse. Verified **red→green** (panics `index out of range` without the guard).
- The `SendVideo` path needs a live session to reach, so it isn't unit-tested here; the guard mirrors the proven `SendImage` pattern.
- `go build ./...` ✅ · `go vet ./...` ✅ · `go test ./...` ✅