### PR TITLE
fix: guard empty MessageIDs in Delivered receipt handler

### DIFF
--- a/event_receipt_test.go
+++ b/event_receipt_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"testing"
+
+	"go.mau.fi/whatsmeow/types"
+	"go.mau.fi/whatsmeow/types/events"
+)
+
+// TestMyEventHandlerEmptyDeliveredReceipt covers the Receipt panic guard: a
+// "Delivered" receipt with an empty MessageIDs slice indexed [0]. In production
+// whatsmeow's dispatch recovers the panic (so it is not a crash), but the
+// receipt is silently dropped and a stack trace is logged. Called directly here
+// there is no dispatch recover, so an empty receipt must not panic.
+func TestMyEventHandlerEmptyDeliveredReceipt(t *testing.T) {
+	s := makeTestServer(t)
+	mycli := &MyClient{userID: "evt-receipt-user", token: "evt-receipt-user", db: s.db, s: s}
+
+	// MessageIDs intentionally left empty — this previously panicked.
+	mycli.myEventHandler(&events.Receipt{
+		Type: types.ReceiptTypeDelivered,
+	})
+}

--- a/wmiau.go
+++ b/wmiau.go
@@ -1144,14 +1144,10 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 			//} else if evt.Type == events.ReceiptTypeDelivered {
 		} else if evt.Type == types.ReceiptTypeDelivered {
 			postmap["state"] = "Delivered"
-			// A Delivered receipt can arrive with an empty MessageIDs slice;
-			// indexing [0] unconditionally panicked (recovered by whatsmeow's
-			// dispatch, but the receipt was dropped and a stack trace logged).
-			deliveredID := ""
-			if len(evt.MessageIDs) > 0 {
-				deliveredID = evt.MessageIDs[0]
-			}
-			log.Info().Str("id", deliveredID).Str("source", evt.SourceString()).Str("timestamp", fmt.Sprintf("%v", evt.Timestamp)).Msg("Message delivered")
+			// Log the whole MessageIDs slice (like the Read branch above). A
+			// Delivered receipt can arrive with an empty slice, so indexing [0]
+			// would panic.
+			log.Info().Strs("id", evt.MessageIDs).Str("source", evt.SourceString()).Str("timestamp", fmt.Sprintf("%v", evt.Timestamp)).Msg("Message delivered")
 		} else {
 			// Discard webhooks for inactive or other delivery types
 			return

--- a/wmiau.go
+++ b/wmiau.go
@@ -1144,7 +1144,14 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 			//} else if evt.Type == events.ReceiptTypeDelivered {
 		} else if evt.Type == types.ReceiptTypeDelivered {
 			postmap["state"] = "Delivered"
-			log.Info().Str("id", evt.MessageIDs[0]).Str("source", evt.SourceString()).Str("timestamp", fmt.Sprintf("%v", evt.Timestamp)).Msg("Message delivered")
+			// A Delivered receipt can arrive with an empty MessageIDs slice;
+			// indexing [0] unconditionally panicked (recovered by whatsmeow's
+			// dispatch, but the receipt was dropped and a stack trace logged).
+			deliveredID := ""
+			if len(evt.MessageIDs) > 0 {
+				deliveredID = evt.MessageIDs[0]
+			}
+			log.Info().Str("id", deliveredID).Str("source", evt.SourceString()).Str("timestamp", fmt.Sprintf("%v", evt.Timestamp)).Msg("Message delivered")
 		} else {
 			// Discard webhooks for inactive or other delivery types
 			return


### PR DESCRIPTION
## Problem

In `myEventHandler`, the `*events.Receipt` "Delivered" branch logs `evt.MessageIDs[0]` with no length check:

```go
} else if evt.Type == types.ReceiptTypeDelivered {
    postmap["state"] = "Delivered"
    log.Info().Str("id", evt.MessageIDs[0])... // panics if MessageIDs is empty
}
```

A delivered receipt can arrive with an empty `MessageIDs` slice, which panics with `index out of range [0] with length 0`. whatsmeow's `dispatchEvent` recovers the panic, so this is **not** a process crash — but the receipt is silently **dropped** (no Delivered webhook fires) and a full stack trace is logged every time it happens. The sibling "Read" branch is already safe (it logs the whole `evt.MessageIDs` slice).

## Fix

Guard the index and fall back to an empty id, so the receipt is handled normally:

```go
deliveredID := ""
if len(evt.MessageIDs) > 0 {
    deliveredID = evt.MessageIDs[0]
}
log.Info().Str("id", deliveredID)...
```

## Testing
- `TestMyEventHandlerEmptyDeliveredReceipt` — feeds a `Delivered` receipt with empty `MessageIDs` directly to `myEventHandler` (no dispatch recover in the test, so the panic surfaces). Verified **red→green**.
- `go build ./...` ✅ · `go vet ./...` ✅ · `go test ./...` ✅