### PR TITLE
fix: correct error responses in Respond (success flag + non-string payloads)

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -5877,20 +5877,30 @@ func (s *server) Respond(w http.ResponseWriter, r *http.Request, status int, dat
 		dataenvelope["error"] = err.Error()
 		dataenvelope["success"] = false
 	} else {
-		// Try to unmarshal into a map first
-		var mydata map[string]interface{}
-		if err := json.Unmarshal([]byte(data.(string)), &mydata); err == nil {
-			dataenvelope["data"] = mydata
-		} else {
-			// If unmarshaling into a map fails, try as a slice
+		// A non-error payload is a success unless the status code says otherwise.
+		// Previously this branch always set success=true and did an unchecked
+		// data.(string), so a non-string value panicked, and a plain non-JSON
+		// string (passed by many handlers on error paths) was dropped while
+		// still reporting success=true.
+		success := status < http.StatusBadRequest
+		if str, ok := data.(string); ok {
+			// Expected to be a JSON object or array; if it isn't, surface the
+			// raw string instead of discarding it.
+			var mydata map[string]interface{}
 			var mySlice []interface{}
-			if err := json.Unmarshal([]byte(data.(string)), &mySlice); err == nil {
+			if json.Unmarshal([]byte(str), &mydata) == nil {
+				dataenvelope["data"] = mydata
+			} else if json.Unmarshal([]byte(str), &mySlice) == nil {
 				dataenvelope["data"] = mySlice
+			} else if success {
+				dataenvelope["data"] = str
 			} else {
-				log.Error().Str("error", fmt.Sprintf("%v", err)).Msg("error unmarshalling JSON")
+				dataenvelope["error"] = str
 			}
+		} else {
+			dataenvelope["data"] = data
 		}
-		dataenvelope["success"] = true
+		dataenvelope["success"] = success
 	}
 
 	if err := json.NewEncoder(w).Encode(dataenvelope); err != nil {

--- a/handlers.go
+++ b/handlers.go
@@ -5884,18 +5884,31 @@ func (s *server) Respond(w http.ResponseWriter, r *http.Request, status int, dat
 		// still reporting success=true.
 		success := status < http.StatusBadRequest
 		if str, ok := data.(string); ok {
-			// Expected to be a JSON object or array; if it isn't, surface the
+			// Only attempt to parse when the payload actually looks like a JSON
+			// object or array — avoids two failed unmarshals on plain text,
+			// the common case for error messages. If it isn't JSON, surface the
 			// raw string instead of discarding it.
-			var mydata map[string]interface{}
-			var mySlice []interface{}
-			if json.Unmarshal([]byte(str), &mydata) == nil {
-				dataenvelope["data"] = mydata
-			} else if json.Unmarshal([]byte(str), &mySlice) == nil {
-				dataenvelope["data"] = mySlice
-			} else if success {
-				dataenvelope["data"] = str
-			} else {
-				dataenvelope["error"] = str
+			trimmed := strings.TrimSpace(str)
+			parsed := false
+			if strings.HasPrefix(trimmed, "{") {
+				var mydata map[string]interface{}
+				if json.Unmarshal([]byte(trimmed), &mydata) == nil {
+					dataenvelope["data"] = mydata
+					parsed = true
+				}
+			} else if strings.HasPrefix(trimmed, "[") {
+				var mySlice []interface{}
+				if json.Unmarshal([]byte(trimmed), &mySlice) == nil {
+					dataenvelope["data"] = mySlice
+					parsed = true
+				}
+			}
+			if !parsed {
+				if success {
+					dataenvelope["data"] = str
+				} else {
+					dataenvelope["error"] = str
+				}
 			}
 		} else {
 			dataenvelope["data"] = data

--- a/respond_test.go
+++ b/respond_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestRespondEnvelope covers the Respond fixes: a non-string payload must not
+// panic (was an unchecked data.(string)), and a plain non-JSON string passed on
+// an error status must report success=false with the message preserved (was
+// success=true with the message dropped). Valid-JSON success responses are
+// unchanged.
+func TestRespondEnvelope(t *testing.T) {
+	s := makeTestServer(t)
+
+	respond := func(status int, data interface{}) map[string]interface{} {
+		rr := httptest.NewRecorder()
+		s.Respond(rr, httptest.NewRequest(http.MethodGet, "/", nil), status, data)
+		var env map[string]interface{}
+		if err := json.Unmarshal(rr.Body.Bytes(), &env); err != nil {
+			t.Fatalf("response is not valid JSON: %s", rr.Body.String())
+		}
+		return env
+	}
+
+	t.Run("error value -> success=false with error", func(t *testing.T) {
+		env := respond(http.StatusInternalServerError, errors.New("boom"))
+		if env["success"] != false || env["error"] != "boom" {
+			t.Errorf("got %v, want success=false error=boom", env)
+		}
+	})
+
+	t.Run("non-JSON string on error status -> success=false, message kept", func(t *testing.T) {
+		env := respond(http.StatusInternalServerError, "failed to set group name")
+		if env["success"] != false {
+			t.Errorf("success = %v, want false (env=%v)", env["success"], env)
+		}
+		if env["error"] == nil && env["data"] == nil {
+			t.Errorf("error message was dropped: %v", env)
+		}
+	})
+
+	t.Run("valid JSON string on 200 -> success=true, data parsed", func(t *testing.T) {
+		env := respond(http.StatusOK, `{"Details":"ok"}`)
+		if env["success"] != true {
+			t.Errorf("success = %v, want true", env["success"])
+		}
+		d, ok := env["data"].(map[string]interface{})
+		if !ok || d["Details"] != "ok" {
+			t.Errorf("data not parsed: %v", env)
+		}
+	})
+
+	t.Run("non-string, non-error value -> no panic, data set", func(t *testing.T) {
+		env := respond(http.StatusOK, map[string]string{"k": "v"}) // previously panicked
+		if env["success"] != true || env["data"] == nil {
+			t.Errorf("got %v, want success=true with data", env)
+		}
+	})
+}


### PR DESCRIPTION
## Problem

`Respond`'s non-error branch had two bugs:

```go
} else {
    if err := json.Unmarshal([]byte(data.(string)), &mydata); err == nil { ... }
    // ...
    dataenvelope["success"] = true   // always true
}
```

1. **Unchecked `data.(string)`** → passing any non-string, non-error value panics with `interface conversion`.
2. **`success` is always `true`** and a non-JSON string is dropped. Many handlers report errors by passing a plain string on an error status, e.g. `s.Respond(w, r, http.StatusInternalServerError, fmt.Sprintf("Failed to get user info: %v", err))`. Because the message isn't valid JSON, both unmarshals fail, it's discarded, and the client receives `{"code":500,"success":true}` — an error reported as success with no detail. This affects ~17 handlers (`GetUser`, `ListGroups`, `GetGroupInfo`, `GroupJoin`, `CreateGroup`, the `SetGroup*` family, `ListNewsletter`, …).

## Fix

- `success := status < http.StatusBadRequest` — derive it from the status code.
- comma-ok the string assertion; a non-string value goes under `data` (no panic).
- a string that isn't a JSON object/array is surfaced under `error` (failure) or `data` (success) instead of being dropped.

Valid-JSON success responses (`Respond(w, r, 200, string(json))`) are unchanged.

## Testing
- `TestRespondEnvelope` — error value → `success:false`+error; non-JSON string at 500 → `success:false` with the message kept; valid JSON at 200 → `success:true` with parsed data; a map value → no panic. Verified **red→green** (old code returns `success:true` and panics on the map case).
- `go build ./...` ✅ · `go vet ./...` ✅ · `go test ./...` ✅