### PR TITLE
fix: preserve event subscriptions on disconnect and reconnect (#305)

### DIFF
--- a/API.md
+++ b/API.md
@@ -374,9 +374,15 @@ Response:
 Disconnects from Whatsapp servers, keeping the session active. This means that if you /session/connect again, it will
 reuse the session and won't require a QR code rescan.
 
+Event subscriptions are **preserved by default**. Pass `clear=true` to also reset them on disconnect.
+
 Endpoint: _/session/disconnect_
 
 Method: **POST**
+
+Query parameters:
+
+* `clear` (optional, boolean): if `true`, clears the user's event subscriptions on disconnect. Defaults to `false` (subscriptions preserved).
 
 
 ```

--- a/event_subscriptions_test.go
+++ b/event_subscriptions_test.go
@@ -18,6 +18,8 @@ func TestResolveConnectEvents(t *testing.T) {
 		{"empty subscribe preserves existing", []string{}, "Message", "Message", false},
 		{"no subscribe, no existing stays empty", nil, "", "", false},
 		{"valid subscribe replaces and flags change", []string{"Message", "ReadReceipt"}, "Old", "Message,ReadReceipt", true},
+		{"subscribe equal to existing yields no change", []string{"Message"}, "Message", "Message", false},
+		{"subscribe equal to multi-value existing yields no change", []string{"Message", "ReadReceipt"}, "Message,ReadReceipt", "Message,ReadReceipt", false},
 		{"unsupported types are filtered", []string{"Message", "Bogus"}, "", "Message", true},
 		{"duplicates are de-duplicated", []string{"Message", "Message"}, "", "Message", true},
 	}

--- a/event_subscriptions_test.go
+++ b/event_subscriptions_test.go
@@ -1,0 +1,87 @@
+package main
+
+import "testing"
+
+// TestResolveConnectEvents covers the Connect-side half of issue #305: a connect
+// call with no subscribe list must PRESERVE the user's existing subscriptions
+// instead of overwriting them with an empty string. A subscribe list still
+// replaces them (keeping only supported, de-duplicated types).
+func TestResolveConnectEvents(t *testing.T) {
+	cases := []struct {
+		name        string
+		subscribe   []string
+		existing    string
+		wantEvents  string
+		wantChanged bool
+	}{
+		{"no subscribe preserves existing", nil, "Message,ReadReceipt", "Message,ReadReceipt", false},
+		{"empty subscribe preserves existing", []string{}, "Message", "Message", false},
+		{"no subscribe, no existing stays empty", nil, "", "", false},
+		{"valid subscribe replaces and flags change", []string{"Message", "ReadReceipt"}, "Old", "Message,ReadReceipt", true},
+		{"unsupported types are filtered", []string{"Message", "Bogus"}, "", "Message", true},
+		{"duplicates are de-duplicated", []string{"Message", "Message"}, "", "Message", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotEvents, gotChanged := resolveConnectEvents(tc.subscribe, tc.existing)
+			if gotEvents != tc.wantEvents || gotChanged != tc.wantChanged {
+				t.Fatalf("resolveConnectEvents(%v, %q) = (%q, %v); want (%q, %v)",
+					tc.subscribe, tc.existing, gotEvents, gotChanged, tc.wantEvents, tc.wantChanged)
+			}
+		})
+	}
+}
+
+// TestSetDisconnectedState covers the Disconnect-side half of issue #305:
+// disconnect preserves event subscriptions by default and only clears them when
+// explicitly asked (clear=true). Verified against the real schema via an
+// in-memory DB.
+func TestSetDisconnectedState(t *testing.T) {
+	const id = "user-305"
+
+	seed := func(t *testing.T, s *server) {
+		t.Helper()
+		if _, err := s.db.Exec(
+			`INSERT INTO users (id, name, token, events, connected) VALUES ($1,$2,$3,$4,$5)`,
+			id, "tester", "tok-305", "Message,ReadReceipt", 1); err != nil {
+			t.Fatalf("seed user: %v", err)
+		}
+	}
+	read := func(t *testing.T, s *server) (events string, connected int) {
+		t.Helper()
+		if err := s.db.QueryRow(`SELECT events, connected FROM users WHERE id=$1`, id).Scan(&events, &connected); err != nil {
+			t.Fatalf("read user: %v", err)
+		}
+		return events, connected
+	}
+
+	t.Run("default preserves events", func(t *testing.T) {
+		s := makeTestServer(t)
+		seed(t, s)
+		if err := s.setDisconnectedState(id, false); err != nil {
+			t.Fatalf("setDisconnectedState: %v", err)
+		}
+		events, connected := read(t, s)
+		if events != "Message,ReadReceipt" {
+			t.Errorf("events = %q; want preserved %q", events, "Message,ReadReceipt")
+		}
+		if connected != 0 {
+			t.Errorf("connected = %d; want 0", connected)
+		}
+	})
+
+	t.Run("clear=true resets events", func(t *testing.T) {
+		s := makeTestServer(t)
+		seed(t, s)
+		if err := s.setDisconnectedState(id, true); err != nil {
+			t.Fatalf("setDisconnectedState: %v", err)
+		}
+		events, connected := read(t, s)
+		if events != "" {
+			t.Errorf("events = %q; want cleared %q", events, "")
+		}
+		if connected != 0 {
+			t.Errorf("connected = %d; want 0", connected)
+		}
+	})
+}

--- a/handlers.go
+++ b/handlers.go
@@ -234,7 +234,8 @@ func resolveConnectEvents(subscribe []string, existing string) (eventstring stri
 			subscribedEvents = append(subscribedEvents, arg)
 		}
 	}
-	return strings.Join(subscribedEvents, ","), true
+	resolved := strings.Join(subscribedEvents, ",")
+	return resolved, resolved != existing
 }
 
 // setDisconnectedState marks a user disconnected. Event subscriptions are kept
@@ -289,10 +290,11 @@ func (s *server) Connect() http.HandlerFunc {
 		if changed {
 			if _, err = s.db.Exec("UPDATE users SET events=$1 WHERE id=$2", eventstring, txtid); err != nil {
 				log.Warn().Msg("Could not set events in users table")
+			} else {
+				log.Info().Str("events", eventstring).Msg("Setting subscribed events")
+				v := updateUserInfo(r.Context().Value("userinfo"), "Events", eventstring)
+				userinfocache.Set(token, v, cache.NoExpiration)
 			}
-			log.Info().Str("events", eventstring).Msg("Setting subscribed events")
-			v := updateUserInfo(r.Context().Value("userinfo"), "Events", eventstring)
-			userinfocache.Set(token, v, cache.NoExpiration)
 		} else {
 			log.Info().Str("events", eventstring).Msg("Preserving existing subscribed events")
 		}
@@ -349,11 +351,12 @@ func (s *server) Disconnect() http.HandlerFunc {
 			clearEvents := r.URL.Query().Get("clear") == "true"
 			if err := s.setDisconnectedState(txtid, clearEvents); err != nil {
 				log.Warn().Str("txtid", txtid).Msg("Could not update users table on disconnect")
-			}
-			log.Info().Str("txtid", txtid).Bool("clearedEvents", clearEvents).Msg("Update DB on disconnection")
-			if clearEvents {
-				v := updateUserInfo(r.Context().Value("userinfo"), "Events", "")
-				userinfocache.Set(token, v, cache.NoExpiration)
+			} else {
+				log.Info().Str("txtid", txtid).Bool("clearedEvents", clearEvents).Msg("Update DB on disconnection")
+				if clearEvents {
+					v := updateUserInfo(r.Context().Value("userinfo"), "Events", "")
+					userinfocache.Set(token, v, cache.NoExpiration)
+				}
 			}
 
 			response := map[string]interface{}{"Details": "Disconnected"}

--- a/handlers.go
+++ b/handlers.go
@@ -216,6 +216,38 @@ func (s *server) authalice(next http.Handler) http.Handler {
 	})
 }
 
+// resolveConnectEvents decides which event-subscription string to persist when
+// a client (re)connects. With no subscribe list the existing subscriptions are
+// preserved instead of being overwritten with an empty value (issue #305);
+// changed reports whether the stored value needs updating.
+func resolveConnectEvents(subscribe []string, existing string) (eventstring string, changed bool) {
+	if len(subscribe) < 1 {
+		return existing, false
+	}
+	var subscribedEvents []string
+	for _, arg := range subscribe {
+		if !Find(supportedEventTypes, arg) {
+			log.Warn().Str("Type", arg).Msg("Event type discarded")
+			continue
+		}
+		if !Find(subscribedEvents, arg) {
+			subscribedEvents = append(subscribedEvents, arg)
+		}
+	}
+	return strings.Join(subscribedEvents, ","), true
+}
+
+// setDisconnectedState marks a user disconnected. Event subscriptions are kept
+// by default and only reset when clearEvents is true (issue #305).
+func (s *server) setDisconnectedState(txtid string, clearEvents bool) error {
+	if clearEvents {
+		_, err := s.db.Exec("UPDATE users SET connected=0,events=$1 WHERE id=$2", "", txtid)
+		return err
+	}
+	_, err := s.db.Exec("UPDATE users SET connected=0 WHERE id=$1", txtid)
+	return err
+}
+
 // Connects to Whatsapp Servers
 func (s *server) Connect() http.HandlerFunc {
 
@@ -249,30 +281,21 @@ func (s *server) Connect() http.HandlerFunc {
 			}
 		}
 
-		var subscribedEvents []string
-		if len(t.Subscribe) < 1 {
-			if !Find(subscribedEvents, "") {
-				subscribedEvents = append(subscribedEvents, "")
+		// Resolve which events to subscribe. With no subscribe list, preserve the
+		// user's existing subscriptions instead of overwriting them (issue #305).
+		existingEvents := r.Context().Value("userinfo").(Values).Get("Events")
+		var changed bool
+		eventstring, changed = resolveConnectEvents(t.Subscribe, existingEvents)
+		if changed {
+			if _, err = s.db.Exec("UPDATE users SET events=$1 WHERE id=$2", eventstring, txtid); err != nil {
+				log.Warn().Msg("Could not set events in users table")
 			}
+			log.Info().Str("events", eventstring).Msg("Setting subscribed events")
+			v := updateUserInfo(r.Context().Value("userinfo"), "Events", eventstring)
+			userinfocache.Set(token, v, cache.NoExpiration)
 		} else {
-			for _, arg := range t.Subscribe {
-				if !Find(supportedEventTypes, arg) {
-					log.Warn().Str("Type", arg).Msg("Event type discarded")
-					continue
-				}
-				if !Find(subscribedEvents, arg) {
-					subscribedEvents = append(subscribedEvents, arg)
-				}
-			}
+			log.Info().Str("events", eventstring).Msg("Preserving existing subscribed events")
 		}
-		eventstring = strings.Join(subscribedEvents, ",")
-		_, err = s.db.Exec("UPDATE users SET events=$1 WHERE id=$2", eventstring, txtid)
-		if err != nil {
-			log.Warn().Msg("Could not set events in users table")
-		}
-		log.Info().Str("events", eventstring).Msg("Setting subscribed events")
-		v := updateUserInfo(r.Context().Value("userinfo"), "Events", eventstring)
-		userinfocache.Set(token, v, cache.NoExpiration)
 
 		log.Info().Str("jid", jid).Msg("Attempt to connect")
 		kill := make(chan bool, 1)
@@ -321,13 +344,17 @@ func (s *server) Disconnect() http.HandlerFunc {
 		if clientManager.GetWhatsmeowClient(txtid).IsConnected() == true {
 			//if clientManager.GetWhatsmeowClient(txtid).IsLoggedIn() == true {
 			log.Info().Str("jid", jid).Msg("Disconnection successfull")
-			_, err := s.db.Exec("UPDATE users SET connected=0,events=$1 WHERE id=$2", "", txtid)
-			if err != nil {
-				log.Warn().Str("txtid", txtid).Msg("Could not set events in users table")
+			// Preserve event subscriptions by default; pass ?clear=true to also
+			// reset them on disconnect (issue #305).
+			clearEvents := r.URL.Query().Get("clear") == "true"
+			if err := s.setDisconnectedState(txtid, clearEvents); err != nil {
+				log.Warn().Str("txtid", txtid).Msg("Could not update users table on disconnect")
 			}
-			log.Info().Str("txtid", txtid).Msg("Update DB on disconnection")
-			v := updateUserInfo(r.Context().Value("userinfo"), "Events", "")
-			userinfocache.Set(token, v, cache.NoExpiration)
+			log.Info().Str("txtid", txtid).Bool("clearedEvents", clearEvents).Msg("Update DB on disconnection")
+			if clearEvents {
+				v := updateUserInfo(r.Context().Value("userinfo"), "Events", "")
+				userinfocache.Set(token, v, cache.NoExpiration)
+			}
 
 			response := map[string]interface{}{"Details": "Disconnected"}
 			responseJson, err := json.Marshal(response)

--- a/static/api/spec.yml
+++ b/static/api/spec.yml
@@ -371,6 +371,14 @@ paths:
             application/json:
               schema:
                 example: { "code": 200, "data": { "Details": "Disconnected" }, "success": true }
+      parameters:
+        - name: clear
+          in: query
+          required: false
+          description: If true, also clears the user's event subscriptions on disconnect. Defaults to false, which preserves them.
+          schema:
+            type: boolean
+            example: false
   /session/logout:
     post:
       tags:


### PR DESCRIPTION
## What & why

Event subscriptions were being silently wiped, forcing users to re-subscribe after every disconnect (#305). Two compounding bugs caused it:

1. **Disconnect** ran `UPDATE users SET ...,events='' ...` on every call, so any disconnect dropped all subscriptions.
2. **Connect** with no `subscribe` field overwrote `events` with an empty string, so reconnecting without re-listing events wiped them too.

## Change

- **Disconnect** (`handlers.go`): subscriptions are now **preserved by default**; pass `?clear=true` to also reset them — the `clear=true` (defaulting to false) option you proposed in #305. Extracted into `setDisconnectedState`.
- **Connect** (`handlers.go`): an absent/empty `subscribe` list now **preserves** the user's existing subscriptions and skips the DB write; a provided list still replaces them (supported, de-duplicated types). Extracted into `resolveConnectEvents`.

The Connect change is the second half of the compound bug in #305 — happy to drop or adjust it if you'd rather keep the connect-without-`subscribe` behavior as it was.

## Testing

- `TestResolveConnectEvents` — pure, table-driven; fails on the old empty-overwrite, passes with the fix.
- `TestSetDisconnectedState` — real in-memory DB (production schema); asserts the default preserves events and `clear=true` resets them.
- Both fail on the old behavior and pass on the fix (red→green).

```
go build ./...                          # ok
go vet ./...                            # ok
go test ./...                           # ok (host)
GOOS=linux GOARCH=amd64 go build .      # ok   — deploys run on Linux
GOOS=linux GOARCH=amd64 go vet ./...    # ok
GOOS=linux GOARCH=amd64 go test -c .    # ok   — test binary links for linux/amd64
```

No change for callers who pass `subscribe` on connect or who explicitly want events cleared (`?clear=true`).

Closes #305.
