### PR TITLE
feat: add GET /user/blocklist to list blocked users

### DIFF
--- a/API.md
+++ b/API.md
@@ -697,6 +697,35 @@ Response:
 
 ---
 
+## Get Blocklist
+
+Returns the list of WhatsApp users currently blocked by the session.
+
+Endpoint: _/user/blocklist_
+
+Method: **GET**
+
+```
+curl -s -X GET -H 'Token: 1234ABCD' http://localhost:8080/user/blocklist
+```
+
+Response:
+
+```json
+{
+  "code": 200,
+  "data": {
+    "Blocklist": [
+      "5491155554445@s.whatsapp.net"
+    ],
+    "DHash": "1234567890"
+  },
+  "success": true
+}
+```
+
+---
+
 
 # Chat
 

--- a/blocklist_test.go
+++ b/blocklist_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+
+	"go.mau.fi/whatsmeow/types"
+)
+
+// TestFormatBlocklist covers the response shaping for GET /user/blocklist:
+// a nil blocklist yields an empty list (never null) and an empty dhash, and a
+// populated blocklist stringifies every JID and passes the dhash through.
+func TestFormatBlocklist(t *testing.T) {
+	t.Run("nil yields empty list and dhash", func(t *testing.T) {
+		got := formatBlocklist(nil)
+		jids, ok := got["Blocklist"].([]string)
+		if !ok {
+			t.Fatalf("Blocklist is not []string: %T", got["Blocklist"])
+		}
+		if len(jids) != 0 {
+			t.Errorf("len(Blocklist) = %d; want 0", len(jids))
+		}
+		if got["DHash"] != "" {
+			t.Errorf("DHash = %v; want empty", got["DHash"])
+		}
+	})
+
+	t.Run("stringifies JIDs and passes dhash through", func(t *testing.T) {
+		j1, ok1 := parseJID("5491155554445")
+		j2, ok2 := parseJID("5491155553935")
+		if !ok1 || !ok2 {
+			t.Fatalf("parseJID failed: ok1=%v ok2=%v", ok1, ok2)
+		}
+		bl := &types.Blocklist{DHash: "1234567890", JIDs: []types.JID{j1, j2}}
+
+		got := formatBlocklist(bl)
+		jids := got["Blocklist"].([]string)
+		if len(jids) != len(bl.JIDs) {
+			t.Fatalf("len(Blocklist) = %d; want %d", len(jids), len(bl.JIDs))
+		}
+		for i := range bl.JIDs {
+			if jids[i] != bl.JIDs[i].String() {
+				t.Errorf("Blocklist[%d] = %q; want %q", i, jids[i], bl.JIDs[i].String())
+			}
+		}
+		if got["DHash"] != "1234567890" {
+			t.Errorf("DHash = %v; want %q", got["DHash"], "1234567890")
+		}
+	})
+}

--- a/blocklist_test.go
+++ b/blocklist_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"go.mau.fi/whatsmeow/types"
@@ -46,4 +49,34 @@ func TestFormatBlocklist(t *testing.T) {
 			t.Errorf("DHash = %v; want %q", got["DHash"], "1234567890")
 		}
 	})
+}
+
+// TestGetBlocklistEndpoint exercises GET /user/blocklist through the real router
+// and auth middleware. With no WhatsApp client connected in tests, the handler
+// returns the "no session" error — the point is to prove the route is wired
+// (not a 404) and authentication passes for a valid token (not a 401).
+func TestGetBlocklistEndpoint(t *testing.T) {
+	s := makeTestServer(t)
+	const token = "tok-blocklist"
+	if _, err := s.db.Exec(
+		`INSERT INTO users (id, name, token, connected) VALUES ($1,$2,$3,$4)`,
+		"u-bl", "tester", token, 0); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/user/blocklist", nil)
+	req.Header.Set("token", token)
+	rr := httptest.NewRecorder()
+	s.router.ServeHTTP(rr, req)
+
+	if rr.Code == http.StatusNotFound {
+		t.Fatalf("route /user/blocklist not registered (404)")
+	}
+	if rr.Code == http.StatusUnauthorized {
+		t.Fatalf("auth failed for a valid token (401): %s", rr.Body.String())
+	}
+	// No client is connected in tests, so the handler reports "no session".
+	if rr.Code != http.StatusInternalServerError || !strings.Contains(rr.Body.String(), "no session") {
+		t.Errorf("expected 500 \"no session\" (route hit, no client); got %d: %s", rr.Code, rr.Body.String())
+	}
 }

--- a/handlers.go
+++ b/handlers.go
@@ -3637,6 +3637,53 @@ func (s *server) UnblockUser() http.HandlerFunc {
 	return s.updateUserBlocklist(events.BlocklistChangeActionUnblock)
 }
 
+// formatBlocklist converts a whatsmeow blocklist into the JSON-friendly shape
+// returned by the blocklist endpoints: the blocked JIDs as strings plus the
+// dhash. A nil blocklist yields an empty list (never null) and an empty dhash.
+func formatBlocklist(blocklist *types.Blocklist) map[string]interface{} {
+	jids := make([]string, 0)
+	dhash := ""
+	if blocklist != nil {
+		jids = make([]string, 0, len(blocklist.JIDs))
+		for _, blockedJID := range blocklist.JIDs {
+			jids = append(jids, blockedJID.String())
+		}
+		dhash = blocklist.DHash
+	}
+	return map[string]interface{}{
+		"Blocklist": jids,
+		"DHash":     dhash,
+	}
+}
+
+// GetBlocklist returns the current list of blocked users.
+func (s *server) GetBlocklist() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		txtid := r.Context().Value("userinfo").(Values).Get("Id")
+		client := clientManager.GetWhatsmeowClient(txtid)
+		if client == nil {
+			s.Respond(w, r, http.StatusInternalServerError, errors.New("no session"))
+			return
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		blocklist, err := client.GetBlocklist(ctx)
+		if err != nil {
+			s.Respond(w, r, http.StatusInternalServerError, errors.New(fmt.Sprintf("failed to get blocklist: %s", err)))
+			return
+		}
+
+		responseJson, err := json.Marshal(formatBlocklist(blocklist))
+		if err != nil {
+			s.Respond(w, r, http.StatusInternalServerError, err)
+		} else {
+			s.Respond(w, r, http.StatusOK, string(responseJson))
+		}
+	}
+}
+
 // Sets Chat Presence (typing/paused/recording audio)
 func (s *server) ChatPresence() http.HandlerFunc {
 

--- a/handlers.go
+++ b/handlers.go
@@ -3641,12 +3641,12 @@ func (s *server) UnblockUser() http.HandlerFunc {
 // returned by the blocklist endpoints: the blocked JIDs as strings plus the
 // dhash. A nil blocklist yields an empty list (never null) and an empty dhash.
 func formatBlocklist(blocklist *types.Blocklist) map[string]interface{} {
-	jids := make([]string, 0)
+	jids := []string{}
 	dhash := ""
 	if blocklist != nil {
-		jids = make([]string, 0, len(blocklist.JIDs))
-		for _, blockedJID := range blocklist.JIDs {
-			jids = append(jids, blockedJID.String())
+		jids = make([]string, len(blocklist.JIDs))
+		for i, blockedJID := range blocklist.JIDs {
+			jids[i] = blockedJID.String()
 		}
 		dhash = blocklist.DHash
 	}
@@ -3666,12 +3666,12 @@ func (s *server) GetBlocklist() http.HandlerFunc {
 			return
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 		defer cancel()
 
 		blocklist, err := client.GetBlocklist(ctx)
 		if err != nil {
-			s.Respond(w, r, http.StatusInternalServerError, errors.New(fmt.Sprintf("failed to get blocklist: %s", err)))
+			s.Respond(w, r, http.StatusInternalServerError, fmt.Errorf("failed to get blocklist: %w", err))
 			return
 		}
 

--- a/routes.go
+++ b/routes.go
@@ -133,6 +133,7 @@ func (s *server) routes() {
 	s.router.Handle("/user/contacts", c.Then(s.GetContacts())).Methods("GET")
 	s.router.Handle("/user/block", c.Then(s.BlockUser())).Methods("POST")
 	s.router.Handle("/user/unblock", c.Then(s.UnblockUser())).Methods("POST")
+	s.router.Handle("/user/blocklist", c.Then(s.GetBlocklist())).Methods("GET")
 	s.router.Handle("/user/lid/{jid}", c.Then(s.GetUserLID())).Methods("GET")
 
 	s.router.Handle("/chat/presence", c.Then(s.ChatPresence())).Methods("POST")

--- a/static/api/spec.yml
+++ b/static/api/spec.yml
@@ -883,6 +883,21 @@ paths:
             application/json:
               schema:
                 example: { "code": 200, "data": { "Details": "User unblocked", "JID": "5491155553935@s.whatsapp.net", "Blocklist": [], "DHash": "1234567891" }, "success": true }
+  /user/blocklist:
+    get:
+      tags:
+        - User
+      summary: Get the current blocklist
+      description: Returns the list of WhatsApp users currently blocked by the session.
+      security:
+        - ApiKeyAuth: []
+      responses:
+        200:
+          description: Current blocklist
+          content:
+            application/json:
+              schema:
+                example: { "code": 200, "data": { "Blocklist": [ "5491155553935@s.whatsapp.net" ], "DHash": "1234567890" }, "success": true }
   /user/lid/{phone}:
     get:
       tags:


### PR DESCRIPTION
## What & why

wuzapi can block and unblock users (`/user/block`, `/user/unblock`) but had no way to **list** who is currently blocked. This adds `GET /user/blocklist`, wrapping whatsmeow's `GetBlocklist`, returning the blocked JIDs plus the blocklist dhash — mirroring the response shape already used by the block/unblock handlers.

## Change

- New `GET /user/blocklist` handler + route.
- Response shaping factored into `formatBlocklist` (a nil blocklist yields an empty list, never `null`).
- OpenAPI spec (`static/api/spec.yml`) and `API.md` updated, so the Swagger page (`/api/`) and the docs show the endpoint.

## Example

```
curl -s -X GET -H 'Token: 1234ABCD' http://localhost:8080/user/blocklist
```
```json
{ "code": 200, "data": { "Blocklist": [ "5491155553935@s.whatsapp.net" ], "DHash": "1234567890" }, "success": true }
```

## Testing

- `TestFormatBlocklist` — unit; nil → empty list + empty dhash, populated → stringifies each JID and passes the dhash through (fails on a broken formatter, passes on the fix).
- `TestGetBlocklistEndpoint` — drives the endpoint through the real router + auth middleware; asserts the route is wired (not 404) and auth passes for a valid token (not 401), returning the "no session" error with no client connected.

```
go build ./...                       # ok
go vet ./...                         # ok
go test ./...                        # ok (host)
GOOS=linux GOARCH=amd64 go build .   # ok
go test ./...  /  -race ./...        # ok on linux/amd64 (Docker golang:1.25)
```

Additive and backward-compatible — no change to existing endpoints.
