### PR TITLE
fix: stop leaking a temp file on every image send

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -1209,6 +1209,18 @@ func (s *server) SendAudio() http.HandlerFunc {
 	}
 }
 
+// jpegThumbnail resizes img to fit within width x height (preserving aspect
+// ratio) and returns it JPEG-encoded. It encodes in memory, so there is no temp
+// file to leak.
+func jpegThumbnail(img image.Image, width, height uint) ([]byte, error) {
+	thumb := resize.Thumbnail(width, height, img, resize.Lanczos3)
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, thumb, nil); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
 // Sends an Image message
 func (s *server) SendImage() http.HandlerFunc {
 
@@ -1312,25 +1324,11 @@ func (s *server) SendImage() http.HandlerFunc {
 			return
 		}
 
-		// resize to width 72 using Lanczos resampling and preserve aspect ratio
-		m := resize.Thumbnail(72, 72, img, resize.Lanczos3)
-
-		tmpFile, err := os.CreateTemp("", "resized-*.jpg")
+		// resize to 72x72 (preserving aspect ratio) and encode the thumbnail in
+		// memory — no temp file, so there is nothing to leak.
+		thumbnailBytes, err = jpegThumbnail(img, 72, 72)
 		if err != nil {
-			s.Respond(w, r, http.StatusInternalServerError, errors.New(fmt.Sprintf("Could not create temp file for thumbnail: %v", err)))
-			return
-		}
-		defer tmpFile.Close()
-
-		// write new image to file
-		if err := jpeg.Encode(tmpFile, m, nil); err != nil {
-			s.Respond(w, r, http.StatusInternalServerError, errors.New(fmt.Sprintf("Failed to encode jpeg: %v", err)))
-			return
-		}
-
-		thumbnailBytes, err = os.ReadFile(tmpFile.Name())
-		if err != nil {
-			s.Respond(w, r, http.StatusInternalServerError, errors.New(fmt.Sprintf("Failed to read %s: %v", tmpFile.Name(), err)))
+			s.Respond(w, r, http.StatusInternalServerError, errors.New(fmt.Sprintf("Failed to encode jpeg thumbnail: %v", err)))
 			return
 		}
 

--- a/handlers.go
+++ b/handlers.go
@@ -1213,6 +1213,9 @@ func (s *server) SendAudio() http.HandlerFunc {
 // ratio) and returns it JPEG-encoded. It encodes in memory, so there is no temp
 // file to leak.
 func jpegThumbnail(img image.Image, width, height uint) ([]byte, error) {
+	if img == nil {
+		return nil, errors.New("cannot create thumbnail from a nil image")
+	}
 	thumb := resize.Thumbnail(width, height, img, resize.Lanczos3)
 	var buf bytes.Buffer
 	if err := jpeg.Encode(&buf, thumb, nil); err != nil {

--- a/jpeg_thumbnail_test.go
+++ b/jpeg_thumbnail_test.go
@@ -42,3 +42,11 @@ func TestJpegThumbnail(t *testing.T) {
 		t.Errorf("thumbnail %dx%d exceeds the 72x72 bound", cfg.Width, cfg.Height)
 	}
 }
+
+// TestJpegThumbnailNil verifies the nil-image guard returns an error instead of
+// panicking (resize.Thumbnail dereferences the image's bounds).
+func TestJpegThumbnailNil(t *testing.T) {
+	if _, err := jpegThumbnail(nil, 72, 72); err == nil {
+		t.Error("expected an error for a nil image, got nil")
+	}
+}

--- a/jpeg_thumbnail_test.go
+++ b/jpeg_thumbnail_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	_ "image/jpeg"
+	"testing"
+)
+
+// TestJpegThumbnail covers the in-memory thumbnail encoding that replaced the
+// leaking temp-file path in SendImage: it must return decodable JPEG bytes
+// bounded by the requested size, preserving aspect ratio.
+func TestJpegThumbnail(t *testing.T) {
+	// A 200x100 source image (2:1 aspect).
+	src := image.NewRGBA(image.Rect(0, 0, 200, 100))
+	for x := 0; x < 200; x++ {
+		for y := 0; y < 100; y++ {
+			src.Set(x, y, color.RGBA{R: uint8(x), G: uint8(y), B: 0, A: 255})
+		}
+	}
+
+	out, err := jpegThumbnail(src, 72, 72)
+	if err != nil {
+		t.Fatalf("jpegThumbnail: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("jpegThumbnail returned no bytes")
+	}
+
+	cfg, format, err := image.DecodeConfig(bytes.NewReader(out))
+	if err != nil {
+		t.Fatalf("output is not a decodable image: %v", err)
+	}
+	if format != "jpeg" {
+		t.Errorf("format = %q; want jpeg", format)
+	}
+	if cfg.Width == 0 || cfg.Height == 0 {
+		t.Errorf("thumbnail has a zero dimension: %dx%d", cfg.Width, cfg.Height)
+	}
+	if cfg.Width > 72 || cfg.Height > 72 {
+		t.Errorf("thumbnail %dx%d exceeds the 72x72 bound", cfg.Width, cfg.Height)
+	}
+}

--- a/jpeg_thumbnail_test.go
+++ b/jpeg_thumbnail_test.go
@@ -4,8 +4,13 @@ import (
 	"bytes"
 	"image"
 	"image/color"
-	_ "image/jpeg"
+	"image/jpeg"
+	_ "image/png"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/nfnt/resize"
 )
 
 // TestJpegThumbnail covers the in-memory thumbnail encoding that replaced the
@@ -48,5 +53,46 @@ func TestJpegThumbnail(t *testing.T) {
 func TestJpegThumbnailNil(t *testing.T) {
 	if _, err := jpegThumbnail(nil, 72, 72); err == nil {
 		t.Error("expected an error for a nil image, got nil")
+	}
+}
+
+// TestJpegThumbnailRealImage runs the fix end-to-end against a real image file
+// shipped with the project. It decodes the image exactly like SendImage does
+// (image.Decode), produces the thumbnail, and asserts the output is byte-for-byte
+// identical to the previous resize+encode — so removing the temp file changed
+// nothing but the mechanism — and is a valid, bounded JPEG.
+func TestJpegThumbnailRealImage(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("static", "images", "background_image.png"))
+	if err != nil {
+		t.Skipf("real image not available: %v", err)
+	}
+
+	img, format, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("decode real image: %v", err)
+	}
+	t.Logf("decoded a real %s image: %dx%d (%T)", format, img.Bounds().Dx(), img.Bounds().Dy(), img)
+
+	got, err := jpegThumbnail(img, 72, 72)
+	if err != nil {
+		t.Fatalf("jpegThumbnail on real image: %v", err)
+	}
+
+	// Reference: the exact resize + JPEG encode the old temp-file path performed.
+	var ref bytes.Buffer
+	if err := jpeg.Encode(&ref, resize.Thumbnail(72, 72, img, resize.Lanczos3), nil); err != nil {
+		t.Fatalf("reference encode: %v", err)
+	}
+	if !bytes.Equal(got, ref.Bytes()) {
+		t.Errorf("thumbnail differs from the resize+encode reference (%d vs %d bytes)", len(got), ref.Len())
+	}
+
+	cfg, f, err := image.DecodeConfig(bytes.NewReader(got))
+	if err != nil {
+		t.Fatalf("thumbnail is not a decodable image: %v", err)
+	}
+	t.Logf("thumbnail produced: %s %dx%d, %d bytes", f, cfg.Width, cfg.Height, len(got))
+	if f != "jpeg" || cfg.Width == 0 || cfg.Width > 72 || cfg.Height > 72 {
+		t.Errorf("unexpected thumbnail: format=%s size=%dx%d", f, cfg.Width, cfg.Height)
 	}
 }


### PR DESCRIPTION
## What & why

`SendImage` created a temp file (`os.CreateTemp`) to hold the resized thumbnail, read it back, and only deferred `Close()` — never `Remove()`. So every image send left a file behind in `TMPDIR`, eventually exhausting disk on busy servers.

## Change

The thumbnail is now resized and JPEG-encoded entirely in memory via a small `jpegThumbnail` helper — no temp file, and two fewer filesystem operations. Behavior is otherwise identical.

## Testing

- `TestJpegThumbnail` — returns a decodable JPEG bounded by the requested size; fails on the un-resized path (red→green).
- `go build ./...` · `go vet ./...` · `go test ./...` — pass on host.
- `GOOS=linux GOARCH=amd64 go build .` + `go test ./...` / `go test -race ./...` — pass on linux/amd64 (Docker `golang:1.25`).

No API change — internal fix.
