### PR TITLE
feat(proxy): add configurable webhook proxy bypass

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -18,6 +18,9 @@ WUZAPI_GLOBAL_WEBHOOK=https://example.com/webhook
 # "json" or "form" for the default
 WEBHOOK_FORMAT=json
 
+# Route webhook deliveries through the per-user proxy when configured (default: true)
+WUZAPI_WEBHOOK_USE_PROXY=true
+
 # WuzAPI Session Configuration
 SESSION_DEVICE_NAME=WuzAPI
 

--- a/handlers.go
+++ b/handlers.go
@@ -767,11 +767,14 @@ func (s *server) GetStatus() http.HandlerFunc {
 		isLoggedIn := clientManager.GetWhatsmeowClient(txtid).IsLoggedIn()
 
 		var proxyURL string
-		var webhookUseProxy bool
-		s.db.QueryRow(
+		webhookUseProxy := *globalWebhookUseProxy
+		err := s.db.QueryRow(
 			"SELECT proxy_url, COALESCE(webhook_use_proxy, true) FROM users WHERE id = $1",
 			txtid,
 		).Scan(&proxyURL, &webhookUseProxy)
+		if err != nil && err != sql.ErrNoRows {
+			log.Warn().Err(err).Str("user_id", txtid).Msg("Failed to query proxy settings for user")
+		}
 		proxyConfig := proxyConfigResponse(proxyURL, webhookUseProxy)
 
 		var s3Enabled bool
@@ -791,7 +794,7 @@ func (s *server) GetStatus() http.HandlerFunc {
 			"media_delivery": "",
 			"retention_days": 0,
 		}
-		err := s.db.QueryRow(`SELECT COALESCE(s3_enabled, false), COALESCE(s3_endpoint, ''), COALESCE(s3_region, ''), COALESCE(s3_bucket, ''), COALESCE(s3_path_style, false), COALESCE(s3_public_url, ''), COALESCE(media_delivery, ''), COALESCE(s3_retention_days, 0) FROM users WHERE id = $1`, txtid).Scan(&s3Enabled, &s3Endpoint, &s3Region, &s3Bucket, &s3PathStyle, &s3PublicURL, &s3MediaDelivery, &s3RetentionDays)
+		err = s.db.QueryRow(`SELECT COALESCE(s3_enabled, false), COALESCE(s3_endpoint, ''), COALESCE(s3_region, ''), COALESCE(s3_bucket, ''), COALESCE(s3_path_style, false), COALESCE(s3_public_url, ''), COALESCE(media_delivery, ''), COALESCE(s3_retention_days, 0) FROM users WHERE id = $1`, txtid).Scan(&s3Enabled, &s3Endpoint, &s3Region, &s3Bucket, &s3PathStyle, &s3PublicURL, &s3MediaDelivery, &s3RetentionDays)
 
 		if err == nil {
 			// Overwrite defaults with actual values if the query succeeded
@@ -5226,17 +5229,18 @@ func (s *server) ListNewsletter() http.HandlerFunc {
 // Admin List users
 func (s *server) ListUsers() http.HandlerFunc {
 	type usersStruct struct {
-		Id         string         `db:"id"`
-		Name       string         `db:"name"`
-		Token      string         `db:"token"`
-		Webhook    string         `db:"webhook"`
-		Jid        string         `db:"jid"`
-		Qrcode     string         `db:"qrcode"`
-		Connected  sql.NullBool   `db:"connected"`
-		Expiration sql.NullInt64  `db:"expiration"`
-		ProxyURL   sql.NullString `db:"proxy_url"`
-		Events     string         `db:"events"`
-		History    sql.NullInt64  `db:"history"`
+		Id              string         `db:"id"`
+		Name            string         `db:"name"`
+		Token           string         `db:"token"`
+		Webhook         string         `db:"webhook"`
+		Jid             string         `db:"jid"`
+		Qrcode          string         `db:"qrcode"`
+		Connected       sql.NullBool   `db:"connected"`
+		Expiration      sql.NullInt64  `db:"expiration"`
+		ProxyURL        sql.NullString `db:"proxy_url"`
+		WebhookUseProxy bool           `db:"webhook_use_proxy"`
+		Events          string         `db:"events"`
+		History         sql.NullInt64  `db:"history"`
 	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
@@ -5247,11 +5251,11 @@ func (s *server) ListUsers() http.HandlerFunc {
 
 		if hasID {
 			// Fetch a single user
-			query = "SELECT id, name, token, webhook, jid, qrcode, connected, expiration, proxy_url, events, history FROM users WHERE id = $1"
+			query = "SELECT id, name, token, webhook, jid, qrcode, connected, expiration, proxy_url, COALESCE(webhook_use_proxy, true) AS webhook_use_proxy, events, history FROM users WHERE id = $1"
 			args = append(args, userID)
 		} else {
 			// Fetch all users
-			query = "SELECT id, name, token, webhook, jid, qrcode, connected, expiration, proxy_url, events, history FROM users"
+			query = "SELECT id, name, token, webhook, jid, qrcode, connected, expiration, proxy_url, COALESCE(webhook_use_proxy, true) AS webhook_use_proxy, events, history FROM users"
 		}
 
 		rows, err := s.db.Queryx(query, args...)
@@ -5296,16 +5300,7 @@ func (s *server) ListUsers() http.HandlerFunc {
 			}
 			// Add proxy_config
 			proxyURL := user.ProxyURL.String
-			var webhookUseProxy bool
-			err = s.db.QueryRow(
-				"SELECT COALESCE(webhook_use_proxy, true) FROM users WHERE id = $1",
-				user.Id,
-			).Scan(&webhookUseProxy)
-			if err != nil && err != sql.ErrNoRows {
-				log.Warn().Err(err).Str("user_id", user.Id).Msg("Failed to query webhook_use_proxy for user")
-				webhookUseProxy = *globalWebhookUseProxy
-			}
-			userMap["proxy_config"] = proxyConfigResponse(proxyURL, webhookUseProxy)
+			userMap["proxy_config"] = proxyConfigResponse(proxyURL, user.WebhookUseProxy)
 			// Add s3_config (search S3 fields in the database)
 			var s3Enabled bool
 			var s3Endpoint, s3Region, s3Bucket, s3PublicURL, s3MediaDelivery string
@@ -6131,13 +6126,25 @@ func (s *server) SetProxy() http.HandlerFunc {
 		}
 
 		// Store proxy configuration in database
-		webhookUseProxy := resolveWebhookUseProxy(t.WebhookUseProxy)
-		_, err = s.db.Exec(
-			"UPDATE users SET proxy_url = $1, webhook_use_proxy = $2 WHERE id = $3",
-			t.ProxyURL,
-			webhookUseProxy,
-			txtid,
-		)
+		var webhookUseProxy bool
+		if t.WebhookUseProxy != nil {
+			webhookUseProxy = *t.WebhookUseProxy
+			_, err = s.db.Exec(
+				"UPDATE users SET proxy_url = $1, webhook_use_proxy = $2 WHERE id = $3",
+				t.ProxyURL,
+				webhookUseProxy,
+				txtid,
+			)
+		} else {
+			err = s.db.QueryRow(
+				"SELECT COALESCE(webhook_use_proxy, true) FROM users WHERE id = $1",
+				txtid,
+			).Scan(&webhookUseProxy)
+			if err != nil {
+				webhookUseProxy = *globalWebhookUseProxy
+			}
+			_, err = s.db.Exec("UPDATE users SET proxy_url = $1 WHERE id = $2", t.ProxyURL, txtid)
+		}
 		if err != nil {
 			s.Respond(w, r, http.StatusInternalServerError, errors.New("failed to save proxy configuration"))
 			return

--- a/handlers.go
+++ b/handlers.go
@@ -766,23 +766,9 @@ func (s *server) GetStatus() http.HandlerFunc {
 		isConnected := clientManager.GetWhatsmeowClient(txtid).IsConnected()
 		isLoggedIn := clientManager.GetWhatsmeowClient(txtid).IsLoggedIn()
 
-		var proxyURL string
+		// Safe defaults so the response always contains every config field.
+		proxyURL := ""
 		webhookUseProxy := *globalWebhookUseProxy
-		err := s.db.QueryRow(
-			"SELECT proxy_url, COALESCE(webhook_use_proxy, true) FROM users WHERE id = $1",
-			txtid,
-		).Scan(&proxyURL, &webhookUseProxy)
-		if err != nil && err != sql.ErrNoRows {
-			log.Warn().Err(err).Str("user_id", txtid).Msg("Failed to query proxy settings for user")
-		}
-		proxyConfig := proxyConfigResponse(proxyURL, webhookUseProxy)
-
-		var s3Enabled bool
-		var s3Endpoint, s3Region, s3Bucket, s3PublicURL, s3MediaDelivery string
-		var s3PathStyle bool
-		var s3RetentionDays int
-
-		// Start with safe defaults so the field is always present in the response
 		s3Config := map[string]interface{}{
 			"enabled":        false,
 			"endpoint":       "",
@@ -794,10 +780,33 @@ func (s *server) GetStatus() http.HandlerFunc {
 			"media_delivery": "",
 			"retention_days": 0,
 		}
-		err = s.db.QueryRow(`SELECT COALESCE(s3_enabled, false), COALESCE(s3_endpoint, ''), COALESCE(s3_region, ''), COALESCE(s3_bucket, ''), COALESCE(s3_path_style, false), COALESCE(s3_public_url, ''), COALESCE(media_delivery, ''), COALESCE(s3_retention_days, 0) FROM users WHERE id = $1`, txtid).Scan(&s3Enabled, &s3Endpoint, &s3Region, &s3Bucket, &s3PathStyle, &s3PublicURL, &s3MediaDelivery, &s3RetentionDays)
+		hmacConfigured := false
 
+		var s3Enabled bool
+		var s3Endpoint, s3Region, s3Bucket, s3PublicURL, s3MediaDelivery string
+		var s3PathStyle bool
+		var s3RetentionDays int
+		var hmacKey []byte
+
+		// One query for proxy, S3 and HMAC config instead of three round-trips.
+		err := s.db.QueryRow(`
+			SELECT COALESCE(proxy_url, ''),
+			       COALESCE(webhook_use_proxy, true),
+			       COALESCE(s3_enabled, false),
+			       COALESCE(s3_endpoint, ''),
+			       COALESCE(s3_region, ''),
+			       COALESCE(s3_bucket, ''),
+			       COALESCE(s3_path_style, false),
+			       COALESCE(s3_public_url, ''),
+			       COALESCE(media_delivery, ''),
+			       COALESCE(s3_retention_days, 0),
+			       hmac_key
+			FROM users WHERE id = $1`, txtid).Scan(
+			&proxyURL, &webhookUseProxy,
+			&s3Enabled, &s3Endpoint, &s3Region, &s3Bucket, &s3PathStyle, &s3PublicURL, &s3MediaDelivery, &s3RetentionDays,
+			&hmacKey,
+		)
 		if err == nil {
-			// Overwrite defaults with actual values if the query succeeded
 			s3Config["enabled"] = s3Enabled
 			s3Config["endpoint"] = s3Endpoint
 			s3Config["region"] = s3Region
@@ -806,18 +815,11 @@ func (s *server) GetStatus() http.HandlerFunc {
 			s3Config["public_url"] = s3PublicURL
 			s3Config["media_delivery"] = s3MediaDelivery
 			s3Config["retention_days"] = s3RetentionDays
-		} else {
-			if err != sql.ErrNoRows {
-				log.Warn().Err(err).Str("user_id", txtid).Msg("Failed to query S3 config for user")
-			}
+			hmacConfigured = len(hmacKey) > 0
+		} else if err != sql.ErrNoRows {
+			log.Warn().Err(err).Str("user_id", txtid).Msg("Failed to query user config for status")
 		}
-
-		var hmacKey []byte
-		err = s.db.QueryRow("SELECT hmac_key FROM users WHERE id = $1", txtid).Scan(&hmacKey)
-		if err != nil && err != sql.ErrNoRows {
-			log.Error().Err(err).Str("userID", txtid).Msg("Failed to query HMAC key")
-		}
-		hmacConfigured := len(hmacKey) > 0
+		proxyConfig := proxyConfigResponse(proxyURL, webhookUseProxy)
 
 		response := map[string]interface{}{
 			"id":              txtid,
@@ -6074,15 +6076,16 @@ func (s *server) SetProxy() http.HandlerFunc {
 
 		// If enable is false, remove proxy configuration
 		if !t.Enable {
-			if t.WebhookUseProxy != nil {
-				_, err = s.db.Exec(
-					"UPDATE users SET proxy_url = '', webhook_use_proxy = $1 WHERE id = $2",
-					*t.WebhookUseProxy,
-					txtid,
-				)
-			} else {
-				_, err = s.db.Exec("UPDATE users SET proxy_url = '' WHERE id = $1", txtid)
+			webhookUseProxy := resolveWebhookUseProxy(t.WebhookUseProxy)
+			if t.WebhookUseProxy == nil {
+				// Preserve existing per-user setting; global default on failure.
+				s.db.QueryRow("SELECT COALESCE(webhook_use_proxy, true) FROM users WHERE id = $1", txtid).Scan(&webhookUseProxy)
 			}
+			_, err = s.db.Exec(
+				"UPDATE users SET proxy_url = '', webhook_use_proxy = $1 WHERE id = $2",
+				webhookUseProxy,
+				txtid,
+			)
 			if err != nil {
 				s.Respond(w, r, http.StatusInternalServerError, errors.New("failed to remove proxy configuration"))
 				return
@@ -6126,25 +6129,17 @@ func (s *server) SetProxy() http.HandlerFunc {
 		}
 
 		// Store proxy configuration in database
-		var webhookUseProxy bool
-		if t.WebhookUseProxy != nil {
-			webhookUseProxy = *t.WebhookUseProxy
-			_, err = s.db.Exec(
-				"UPDATE users SET proxy_url = $1, webhook_use_proxy = $2 WHERE id = $3",
-				t.ProxyURL,
-				webhookUseProxy,
-				txtid,
-			)
-		} else {
-			err = s.db.QueryRow(
-				"SELECT COALESCE(webhook_use_proxy, true) FROM users WHERE id = $1",
-				txtid,
-			).Scan(&webhookUseProxy)
-			if err != nil {
-				webhookUseProxy = *globalWebhookUseProxy
-			}
-			_, err = s.db.Exec("UPDATE users SET proxy_url = $1 WHERE id = $2", t.ProxyURL, txtid)
+		webhookUseProxy := resolveWebhookUseProxy(t.WebhookUseProxy)
+		if t.WebhookUseProxy == nil {
+			// Preserve existing per-user setting; global default on failure.
+			s.db.QueryRow("SELECT COALESCE(webhook_use_proxy, true) FROM users WHERE id = $1", txtid).Scan(&webhookUseProxy)
 		}
+		_, err = s.db.Exec(
+			"UPDATE users SET proxy_url = $1, webhook_use_proxy = $2 WHERE id = $3",
+			t.ProxyURL,
+			webhookUseProxy,
+			txtid,
+		)
 		if err != nil {
 			s.Respond(w, r, http.StatusInternalServerError, errors.New("failed to save proxy configuration"))
 			return

--- a/handlers.go
+++ b/handlers.go
@@ -767,11 +767,12 @@ func (s *server) GetStatus() http.HandlerFunc {
 		isLoggedIn := clientManager.GetWhatsmeowClient(txtid).IsLoggedIn()
 
 		var proxyURL string
-		s.db.QueryRow("SELECT proxy_url FROM users WHERE id = $1", txtid).Scan(&proxyURL)
-		proxyConfig := map[string]interface{}{
-			"enabled":   proxyURL != "",
-			"proxy_url": proxyURL,
-		}
+		var webhookUseProxy bool
+		s.db.QueryRow(
+			"SELECT proxy_url, COALESCE(webhook_use_proxy, true) FROM users WHERE id = $1",
+			txtid,
+		).Scan(&proxyURL, &webhookUseProxy)
+		proxyConfig := proxyConfigResponse(proxyURL, webhookUseProxy)
 
 		var s3Enabled bool
 		var s3Endpoint, s3Region, s3Bucket, s3PublicURL, s3MediaDelivery string
@@ -5295,10 +5296,16 @@ func (s *server) ListUsers() http.HandlerFunc {
 			}
 			// Add proxy_config
 			proxyURL := user.ProxyURL.String
-			userMap["proxy_config"] = map[string]interface{}{
-				"enabled":   proxyURL != "",
-				"proxy_url": proxyURL,
+			var webhookUseProxy bool
+			err = s.db.QueryRow(
+				"SELECT COALESCE(webhook_use_proxy, true) FROM users WHERE id = $1",
+				user.Id,
+			).Scan(&webhookUseProxy)
+			if err != nil && err != sql.ErrNoRows {
+				log.Warn().Err(err).Str("user_id", user.Id).Msg("Failed to query webhook_use_proxy for user")
+				webhookUseProxy = *globalWebhookUseProxy
 			}
+			userMap["proxy_config"] = proxyConfigResponse(proxyURL, webhookUseProxy)
 			// Add s3_config (search S3 fields in the database)
 			var s3Enabled bool
 			var s3Endpoint, s3Region, s3Bucket, s3PublicURL, s3MediaDelivery string
@@ -5358,11 +5365,6 @@ func (s *server) AddUser() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
-		type ProxyConfig struct {
-			Enabled  bool   `json:"enabled"`
-			ProxyURL string `json:"proxyURL"`
-		}
-
 		// Parse the request body
 		var user struct {
 			Name        string       `json:"name"`
@@ -5396,6 +5398,7 @@ func (s *server) AddUser() http.HandlerFunc {
 		if user.ProxyConfig == nil {
 			user.ProxyConfig = &ProxyConfig{}
 		}
+		webhookUseProxy := resolveWebhookUseProxy(user.ProxyConfig.WebhookUseProxy)
 		if user.S3Config == nil {
 			user.S3Config = &S3Config{}
 		}
@@ -5480,8 +5483,8 @@ func (s *server) AddUser() http.HandlerFunc {
 
 		// Insert user with all proxy, S3 and HMAC fields
 		if _, err = s.db.Exec(
-			"INSERT INTO users (id, name, token, webhook, expiration, events, jid, qrcode, proxy_url, s3_enabled, s3_endpoint, s3_region, s3_bucket, s3_access_key, s3_secret_key, s3_path_style, s3_public_url, media_delivery, s3_retention_days, hmac_key, history) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)",
-			id, user.Name, user.Token, user.Webhook, user.Expiration, user.Events, "", "", user.ProxyConfig.ProxyURL,
+			"INSERT INTO users (id, name, token, webhook, expiration, events, jid, qrcode, proxy_url, webhook_use_proxy, s3_enabled, s3_endpoint, s3_region, s3_bucket, s3_access_key, s3_secret_key, s3_path_style, s3_public_url, media_delivery, s3_retention_days, hmac_key, history) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)",
+			id, user.Name, user.Token, user.Webhook, user.Expiration, user.Events, "", "", user.ProxyConfig.ProxyURL, webhookUseProxy,
 			user.S3Config.Enabled, user.S3Config.Endpoint, user.S3Config.Region, user.S3Config.Bucket, user.S3Config.AccessKey, user.S3Config.SecretKey, user.S3Config.PathStyle, user.S3Config.PublicURL, user.S3Config.MediaDelivery, user.S3Config.RetentionDays, encryptedHmacKey, user.History,
 		); err != nil {
 			log.Error().Str("error", fmt.Sprintf("%v", err)).Msg("admin DB error")
@@ -5511,10 +5514,7 @@ func (s *server) AddUser() http.HandlerFunc {
 		}
 
 		// Build response like GET /admin/users
-		proxyConfig := map[string]interface{}{
-			"enabled":   user.ProxyConfig.Enabled,
-			"proxy_url": user.ProxyConfig.ProxyURL,
-		}
+		proxyConfig := proxyConfigResponse(user.ProxyConfig.ProxyURL, webhookUseProxy)
 		s3Config := map[string]interface{}{
 			"enabled":        user.S3Config.Enabled,
 			"endpoint":       user.S3Config.Endpoint,
@@ -5549,11 +5549,6 @@ func (s *server) AddUser() http.HandlerFunc {
 func (s *server) EditUser() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-
-		type ProxyConfig struct {
-			Enabled  bool   `json:"enabled"`
-			ProxyURL string `json:"proxyURL"`
-		}
 
 		// Get the user ID from the request URL
 		vars := mux.Vars(r)
@@ -5654,6 +5649,9 @@ func (s *server) EditUser() http.HandlerFunc {
 				addField("proxy_url", user.ProxyConfig.ProxyURL, true)
 			} else {
 				addField("proxy_url", "", true)
+			}
+			if user.ProxyConfig.WebhookUseProxy != nil {
+				addField("webhook_use_proxy", *user.ProxyConfig.WebhookUseProxy, true)
 			}
 		}
 
@@ -6056,8 +6054,9 @@ func (s *server) SetHistory() http.HandlerFunc {
 // Set proxy
 func (s *server) SetProxy() http.HandlerFunc {
 	type proxyStruct struct {
-		ProxyURL string `json:"proxy_url"` // Format: "socks5://user:pass@host:port" or "http://host:port"
-		Enable   bool   `json:"enable"`    // Whether to enable or disable proxy
+		ProxyURL        string `json:"proxy_url"` // Format: "socks5://user:pass@host:port" or "http://host:port"
+		Enable          bool   `json:"enable"`    // Whether to enable or disable proxy
+		WebhookUseProxy *bool  `json:"webhook_use_proxy,omitempty"`
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -6080,7 +6079,15 @@ func (s *server) SetProxy() http.HandlerFunc {
 
 		// If enable is false, remove proxy configuration
 		if !t.Enable {
-			_, err = s.db.Exec("UPDATE users SET proxy_url = '' WHERE id = $1", txtid)
+			if t.WebhookUseProxy != nil {
+				_, err = s.db.Exec(
+					"UPDATE users SET proxy_url = '', webhook_use_proxy = $1 WHERE id = $2",
+					*t.WebhookUseProxy,
+					txtid,
+				)
+			} else {
+				_, err = s.db.Exec("UPDATE users SET proxy_url = '' WHERE id = $1", txtid)
+			}
 			if err != nil {
 				s.Respond(w, r, http.StatusInternalServerError, errors.New("failed to remove proxy configuration"))
 				return
@@ -6124,7 +6131,13 @@ func (s *server) SetProxy() http.HandlerFunc {
 		}
 
 		// Store proxy configuration in database
-		_, err = s.db.Exec("UPDATE users SET proxy_url = $1 WHERE id = $2", t.ProxyURL, txtid)
+		webhookUseProxy := resolveWebhookUseProxy(t.WebhookUseProxy)
+		_, err = s.db.Exec(
+			"UPDATE users SET proxy_url = $1, webhook_use_proxy = $2 WHERE id = $3",
+			t.ProxyURL,
+			webhookUseProxy,
+			txtid,
+		)
 		if err != nil {
 			s.Respond(w, r, http.StatusInternalServerError, errors.New("failed to save proxy configuration"))
 			return
@@ -6140,8 +6153,9 @@ func (s *server) SetProxy() http.HandlerFunc {
 		}
 
 		response := map[string]interface{}{
-			"Details":  "Proxy configured successfully",
-			"ProxyURL": t.ProxyURL,
+			"Details":           "Proxy configured successfully",
+			"ProxyURL":          t.ProxyURL,
+			"webhook_use_proxy": webhookUseProxy,
 		}
 		responseJson, err := json.Marshal(response)
 		if err != nil {

--- a/helpers.go
+++ b/helpers.go
@@ -90,6 +90,33 @@ type WebhookErrorPayload struct {
 	AttemptTime      time.Time              `json:"attemptTime"`
 	ErrorMessage     string                 `json:"errorMessage"`
 }
+
+// ProxyConfig holds per-user proxy settings for WhatsApp and webhook delivery.
+type ProxyConfig struct {
+	Enabled         bool  `json:"enabled"`
+	ProxyURL        string `json:"proxyURL"`
+	WebhookUseProxy *bool `json:"webhookUseProxy,omitempty"`
+}
+
+func resolveWebhookUseProxy(perUser *bool) bool {
+	if perUser != nil {
+		return *perUser
+	}
+	return *globalWebhookUseProxy
+}
+
+func proxyConfigResponse(proxyURL string, webhookUseProxy bool) map[string]interface{} {
+	return map[string]interface{}{
+		"enabled":           proxyURL != "",
+		"proxy_url":         proxyURL,
+		"webhook_use_proxy": webhookUseProxy,
+	}
+}
+
+func applyRestyProxy(client *resty.Client, proxyURL string) {
+	client.SetProxy(proxyURL)
+}
+
 type openGraphResult struct {
 	Title       string
 	Description string

--- a/helpers.go
+++ b/helpers.go
@@ -113,10 +113,6 @@ func proxyConfigResponse(proxyURL string, webhookUseProxy bool) map[string]inter
 	}
 }
 
-func applyRestyProxy(client *resty.Client, proxyURL string) {
-	client.SetProxy(proxyURL)
-}
-
 type openGraphResult struct {
 	Title       string
 	Description string

--- a/main.go
+++ b/main.go
@@ -69,6 +69,7 @@ var (
 	webhookRetryCount        = flag.Int("retrycount", 5, "Number of times to retry failed webhooks")
 	webhookRetryDelaySeconds = flag.Int("retrydelay", 30, "Delay in seconds between webhook retries")
 	webhookErrorQueueName    = flag.String("errorqueue", "webhook_errors", "RabbitMQ queue name for failed webhooks")
+	globalWebhookUseProxy    = flag.Bool("webhookuseproxy", true, "Route webhook deliveries through the per-user proxy when configured")
 
 	container        *sqlstore.Container
 	clientManager    = NewClientManager()
@@ -262,6 +263,13 @@ func main() {
 	if v := os.Getenv("WEBHOOK_ERROR_QUEUE_NAME"); v != "" {
 		*webhookErrorQueueName = v
 	}
+	if v := os.Getenv("WUZAPI_WEBHOOK_USE_PROXY"); v != "" {
+		*globalWebhookUseProxy = strings.ToLower(v) == "true" || v == "1"
+	}
+
+	log.Info().
+		Bool("use_proxy", *globalWebhookUseProxy).
+		Msg("Webhook Proxy Configured")
 
 	log.Info().
 		Bool("enabled", *webhookRetryEnabled).

--- a/migrations.go
+++ b/migrations.go
@@ -75,6 +75,11 @@ var migrations = []Migration{
 		Name:  "add_whatsmeow_message_secrets_message_id_idx",
 		UpSQL: addWhatsmeowMessageSecretsMessageIDIndexSQL,
 	},
+	{
+		ID:    10,
+		Name:  "add_webhook_use_proxy",
+		UpSQL: addWebhookUseProxySQL,
+	},
 }
 
 const changeIDToStringSQL = `
@@ -226,6 +231,18 @@ BEGIN
 	CREATE INDEX IF NOT EXISTS whatsmeow_message_secrets_message_id_idx
 	ON whatsmeow_message_secrets (message_id);
 END $$;
+-- SQLite version (handled in code)
+`
+
+const addWebhookUseProxySQL = `
+-- PostgreSQL version
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'webhook_use_proxy') THEN
+        ALTER TABLE users ADD COLUMN webhook_use_proxy BOOLEAN DEFAULT TRUE;
+    END IF;
+END $$;
+
 -- SQLite version (handled in code)
 `
 
@@ -453,6 +470,12 @@ func applyMigration(db *sqlx.DB, migration Migration) error {
 	} else if migration.ID == 9 {
 		if db.DriverName() == "sqlite" {
 			err = nil
+		} else {
+			_, err = tx.Exec(migration.UpSQL)
+		}
+	} else if migration.ID == 10 {
+		if db.DriverName() == "sqlite" {
+			err = addColumnIfNotExistsSQLite(tx, "users", "webhook_use_proxy", "BOOLEAN DEFAULT 1")
 		} else {
 			_, err = tx.Exec(migration.UpSQL)
 		}

--- a/proxy_config_test.go
+++ b/proxy_config_test.go
@@ -1,0 +1,42 @@
+package main
+
+import "testing"
+
+func TestResolveWebhookUseProxy(t *testing.T) {
+	original := *globalWebhookUseProxy
+	defer func() { *globalWebhookUseProxy = original }()
+
+	*globalWebhookUseProxy = true
+	if got := resolveWebhookUseProxy(nil); got != true {
+		t.Fatalf("expected global default true, got %v", got)
+	}
+
+	useProxy := false
+	if got := resolveWebhookUseProxy(&useProxy); got != false {
+		t.Fatalf("expected per-user override false, got %v", got)
+	}
+
+	*globalWebhookUseProxy = false
+	if got := resolveWebhookUseProxy(nil); got != false {
+		t.Fatalf("expected global default false, got %v", got)
+	}
+
+	useProxy = true
+	if got := resolveWebhookUseProxy(&useProxy); got != true {
+		t.Fatalf("expected per-user override true, got %v", got)
+	}
+}
+
+func TestProxyConfigResponse(t *testing.T) {
+	response := proxyConfigResponse("socks5://127.0.0.1:1080", false)
+
+	if response["enabled"] != true {
+		t.Fatalf("expected enabled true when proxy URL is set, got %v", response["enabled"])
+	}
+	if response["proxy_url"] != "socks5://127.0.0.1:1080" {
+		t.Fatalf("unexpected proxy_url: %v", response["proxy_url"])
+	}
+	if response["webhook_use_proxy"] != false {
+		t.Fatalf("expected webhook_use_proxy false, got %v", response["webhook_use_proxy"])
+	}
+}

--- a/static/api/spec.yml
+++ b/static/api/spec.yml
@@ -468,6 +468,10 @@ paths:
                 enable:
                   type: boolean
                   description: Whether to enable or disable the proxy.
+                webhook_use_proxy:
+                  type: boolean
+                  description: Whether webhook deliveries use the configured proxy. When omitted, the existing per-user value is preserved.
+                  example: true
               required:
                 - proxy_url
                 - enable
@@ -485,6 +489,9 @@ paths:
                   ProxyURL:
                     type: string
                     example: socks5://user:pass@host:port
+                  webhook_use_proxy:
+                    type: boolean
+                    example: true
         "400":
           description: Bad Request
         "500":

--- a/static/api/spec.yml
+++ b/static/api/spec.yml
@@ -2220,6 +2220,10 @@ definitions:
           proxy_url:
             type: string
             example: "https://serverproxy.com:9080"
+          webhook_use_proxy:
+            type: boolean
+            example: true
+            description: "Whether webhook deliveries use the configured proxy"
       s3_config:
         type: object
         properties:
@@ -2282,6 +2286,10 @@ definitions:
             type: string
             example: "https://serverproxy.com:9080"
             description: "Proxy URL to use for the user. Format: socks5://user:pass@host:port or http://host:port"
+          webhookUseProxy:
+            type: boolean
+            example: true
+            description: "Route webhook deliveries through the configured proxy. Defaults to the WUZAPI_WEBHOOK_USE_PROXY server setting (true)."
       s3Config:
         type: object
         properties:

--- a/static/dashboard/css/app.css
+++ b/static/dashboard/css/app.css
@@ -912,11 +912,13 @@ a#menulogout, a:visited#menulogout {
 }
 
 /* Proxy Configuration Styles */
-#proxyUrlField {
+#proxyUrlField,
+#proxyWebhookUseProxyField {
   display: none;
 }
 
-#proxyUrlField.show {
+#proxyUrlField.show,
+#proxyWebhookUseProxyField.show {
   display: block;
 }
 

--- a/static/dashboard/index.html
+++ b/static/dashboard/index.html
@@ -130,7 +130,7 @@
       <div class="purple card hidden widget" style="cursor: pointer;" id="proxyConfig">
         <div class="content"><a class="ui purple right ribbon label">Config</a>
           <div class="header">Proxy Settings</div>
-          <div class="description">Configure proxy for WhatsApp connections.</div>
+          <div class="description">Configure proxy for WhatsApp and webhook delivery.</div>
         </div>
       </div>
       <div class="purple card hidden widget" style="cursor: pointer;" id="webhookConfig">
@@ -492,7 +492,7 @@
     <div class="content">
       <div class="ui info message">
         <div class="header">Proxy Settings</div>
-        <p>Configure HTTP/HTTPS or SOCKS5 proxy for WhatsApp connections. Useful for network restrictions or enhanced privacy.</p>
+        <p>Configure HTTP/HTTPS or SOCKS5 proxy for WhatsApp connections. Optionally route webhook deliveries through the same proxy or send them directly to your backend.</p>
       </div>
       <div class="ui form">
         <div class="field">
@@ -506,6 +506,13 @@
           <label>Proxy URL</label>
           <input id="proxyUrl" type="text" placeholder="http://proxy.example.com:8080 or socks5://user:pass@proxy.example.com:1080">
           <small>Include protocol (http://, https://, or socks5://) and port. Authentication can be included in URL format.</small>
+        </div>
+        <div class="field" id="proxyWebhookUseProxyField">
+          <div class="ui toggle checkbox" id="proxyWebhookUseProxyToggle">
+            <input type="checkbox" id="proxyWebhookUseProxy" checked>
+            <label>Use proxy for webhook delivery</label>
+          </div>
+          <small>When enabled, outgoing webhook POSTs use the configured proxy. Disable to reach your application backend directly while WhatsApp traffic still uses the proxy.</small>
         </div>
       </div>
     </div>
@@ -663,6 +670,13 @@
           <label>Proxy URL</label>
           <input type="text" name="proxy_url" placeholder="http://proxy.example.com:8080 or socks5://user:pass@proxy.example.com:1080">
           <small>Include protocol (http://, https://, or socks5://) and port. Authentication can be included in URL format.</small>
+        </div>
+        <div class="field" id="addInstanceProxyWebhookUseProxyField" style="display: none;">
+          <div class="ui toggle checkbox" id="addInstanceProxyWebhookUseProxyToggle">
+            <input type="checkbox" name="proxy_webhook_use_proxy" checked>
+            <label>Use proxy for webhook delivery</label>
+          </div>
+          <small>Disable to send webhooks directly to your backend while WhatsApp traffic uses the proxy.</small>
         </div>
 
         <!-- S3 Configuration -->

--- a/static/dashboard/js/app.js
+++ b/static/dashboard/js/app.js
@@ -62,11 +62,14 @@ document.addEventListener('DOMContentLoaded', function() {
       const enabled = $('#proxyEnabled').is(':checked');
       if (enabled) {
         $('#proxyUrlField').addClass('show');
+        $('#proxyWebhookUseProxyField').addClass('show');
       } else {
         $('#proxyUrlField').removeClass('show');
+        $('#proxyWebhookUseProxyField').removeClass('show');
       }
     }
   });
+  $('#proxyWebhookUseProxyToggle').checkbox();
 
   // Initialize add instance proxy toggle
   $('#addInstanceProxyToggle').checkbox({
@@ -74,12 +77,15 @@ document.addEventListener('DOMContentLoaded', function() {
       const enabled = $('input[name="proxy_enabled"]').is(':checked');
       if (enabled) {
         $('#addInstanceProxyUrlField').show();
+        $('#addInstanceProxyWebhookUseProxyField').show();
       } else {
         $('#addInstanceProxyUrlField').hide();
+        $('#addInstanceProxyWebhookUseProxyField').hide();
         $('input[name="proxy_url"]').val('');
       }
     }
   });
+  $('#addInstanceProxyWebhookUseProxyToggle').checkbox();
 
   // Initialize add instance S3 toggle
   $('#addInstanceS3Toggle').checkbox({
@@ -495,6 +501,8 @@ document.addEventListener('DOMContentLoaded', function() {
       $('#addInstanceS3Toggle').checkbox('set unchecked');
       $('#addInstanceHmacToggle').checkbox('set unchecked');
       $('#addInstanceProxyUrlField').hide();
+      $('#addInstanceProxyWebhookUseProxyField').hide();
+      $('#addInstanceProxyWebhookUseProxyToggle').checkbox('set checked');
       $('#addInstanceS3Fields').hide();
       $('#addInstanceHmacKeyWarningMessage').hide();
       $('#addInstanceHmacKeyField').hide();
@@ -513,9 +521,11 @@ async function addInstance(data) {
 
   // Build proxy configuration
   const proxyEnabled = data.proxy_enabled === 'on' || data.proxy_enabled === true;
+  const proxyWebhookUseProxy = data.proxy_webhook_use_proxy === 'on' || data.proxy_webhook_use_proxy === true;
   const proxyConfig = {
     enabled: proxyEnabled,
-    proxyURL: proxyEnabled ? (data.proxy_url || '') : ''
+    proxyURL: proxyEnabled ? (data.proxy_url || '') : '',
+    webhookUseProxy: proxyEnabled ? proxyWebhookUseProxy : true
   };
   
   // Build S3 configuration
@@ -1262,6 +1272,10 @@ function populateInstances(instances) {
                               <div class="content">${instance.proxy_config.proxy_url || 'Not configured'}</div>
                           </div>
                           <div class="item">
+                              <div class="header">Webhook Proxy</div>
+                              <div class="content">${instance.proxy_config.webhook_use_proxy === false ? 'Bypass proxy' : 'Use proxy'}</div>
+                          </div>
+                          <div class="item">
                               <div class="header">S3</div>
                               <div class="content">${instance.s3_config.enabled ? 'Enabled' : 'Disabled'}</div>
                           </div>
@@ -1682,6 +1696,7 @@ async function loadProxyConfig() {
         const proxyConfig = data.data.proxy_config;
         const proxyUrl = proxyConfig.proxy_url || '';
         const enabled = proxyConfig.enabled || false;
+        const webhookUseProxy = proxyConfig.webhook_use_proxy !== false;
         
         // Set checkbox state
         $('#proxyEnabled').prop('checked', enabled);
@@ -1689,12 +1704,17 @@ async function loadProxyConfig() {
         
         // Set proxy URL
         $('#proxyUrl').val(proxyUrl);
+
+        $('#proxyWebhookUseProxy').prop('checked', webhookUseProxy);
+        $('#proxyWebhookUseProxyToggle').checkbox(webhookUseProxy ? 'set checked' : 'set unchecked');
         
         // Show/hide URL field based on enabled state
         if (enabled) {
           $('#proxyUrlField').addClass('show');
+          $('#proxyWebhookUseProxyField').addClass('show');
         } else {
           $('#proxyUrlField').removeClass('show');
+          $('#proxyWebhookUseProxyField').removeClass('show');
         }
       } else {
         // No proxy config, set defaults
@@ -1702,6 +1722,9 @@ async function loadProxyConfig() {
         $('#proxyEnabledToggle').checkbox('set unchecked');
         $('#proxyUrl').val('');
         $('#proxyUrlField').removeClass('show');
+        $('#proxyWebhookUseProxy').prop('checked', true);
+        $('#proxyWebhookUseProxyToggle').checkbox('set checked');
+        $('#proxyWebhookUseProxyField').removeClass('show');
       }
     }
   } catch (error) {
@@ -1717,12 +1740,14 @@ async function saveProxyConfig() {
   
   const enabled = $('#proxyEnabled').is(':checked');
   const proxyUrl = $('#proxyUrl').val().trim();
+  const webhookUseProxy = $('#proxyWebhookUseProxy').is(':checked');
   
   // If proxy is disabled, send disable request
   if (!enabled) {
     const config = {
       enable: false,
-      proxy_url: ''
+      proxy_url: '',
+      webhook_use_proxy: webhookUseProxy
     };
     
     try {
@@ -1760,7 +1785,8 @@ async function saveProxyConfig() {
   
   const config = {
     enable: true,
-    proxy_url: proxyUrl
+    proxy_url: proxyUrl,
+    webhook_use_proxy: webhookUseProxy
   };
   
   try {

--- a/wmiau.go
+++ b/wmiau.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"crypto/tls"
+	"database/sql"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -471,11 +472,14 @@ func (s *server) startClient(userID string, textjid string, token string, kill c
 	})
 
 	var proxyURL string
-	var webhookUseProxy bool
+	webhookUseProxy := *globalWebhookUseProxy
 	err = s.db.QueryRow(
 		"SELECT proxy_url, COALESCE(webhook_use_proxy, true) FROM users WHERE id=$1",
 		userID,
 	).Scan(&proxyURL, &webhookUseProxy)
+	if err != nil && err != sql.ErrNoRows {
+		log.Error().Err(err).Str("user_id", userID).Msg("Failed to query proxy settings from database")
+	}
 	if err == nil && proxyURL != "" {
 		parsed, perr := url.Parse(proxyURL)
 		if perr != nil {

--- a/wmiau.go
+++ b/wmiau.go
@@ -453,14 +453,16 @@ func (s *server) startClient(userID string, textjid string, token string, kill c
 	// Store the MyClient in clientManager
 	clientManager.SetMyClient(userID, &mycli)
 
-	httpClient := resty.New()
-	httpClient.SetRedirectPolicy(resty.FlexibleRedirectPolicy(15))
+	// Webhook client: intentionally created without a proxy so webhook deliveries
+	// bypass any WhatsApp proxy configured for the websocket connection.
+	webhookClient := resty.New()
+	webhookClient.SetRedirectPolicy(resty.FlexibleRedirectPolicy(15))
 	if *waDebug == "DEBUG" {
-		httpClient.SetDebug(true)
+		webhookClient.SetDebug(true)
 	}
-	httpClient.SetTimeout(30 * time.Second)
-	httpClient.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
-	httpClient.OnError(func(req *resty.Request, err error) {
+	webhookClient.SetTimeout(30 * time.Second)
+	webhookClient.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
+	webhookClient.OnError(func(req *resty.Request, err error) {
 		if v, ok := err.(*resty.ResponseError); ok {
 			// v.Response contains the last response from the server
 			// v.Err contains the original error
@@ -469,7 +471,8 @@ func (s *server) startClient(userID string, textjid string, token string, kill c
 		}
 	})
 
-	// Set proxy if defined in DB (assumes users table contains proxy_url column)
+	// Set proxy for the WhatsApp connection if defined in DB (assumes users table contains proxy_url column).
+	// The webhook client above is deliberately left without a proxy.
 	var proxyURL string
 	err = s.db.Get(&proxyURL, "SELECT proxy_url FROM users WHERE id=$1", userID)
 	if err == nil && proxyURL != "" {
@@ -485,18 +488,16 @@ func (s *server) startClient(userID string, textjid string, token string, kill c
 				if derr != nil {
 					log.Warn().Err(derr).Str("proxy", proxyURL).Msg("Failed to build SOCKS proxy dialer, skipping proxy setup")
 				} else {
-					httpClient.SetProxy(proxyURL)
 					client.SetSOCKSProxy(dialer, whatsmeow.SetProxyOptions{})
-					log.Info().Msg("SOCKS proxy configured successfully")
+					log.Info().Msg("SOCKS proxy configured for WhatsApp connection")
 				}
 			} else {
-				httpClient.SetProxy(proxyURL)
 				client.SetProxyAddress(parsed.String(), whatsmeow.SetProxyOptions{})
-				log.Info().Msg("HTTP/HTTPS proxy configured successfully")
+				log.Info().Msg("HTTP/HTTPS proxy configured for WhatsApp connection")
 			}
 		}
 	}
-	clientManager.SetHTTPClient(userID, httpClient)
+	clientManager.SetHTTPClient(userID, webhookClient)
 
 	// Initialize S3 client if configured (needed when user reconnects after container restart - connectOnStartup only runs for connected=1)
 	GetS3Manager().EnsureClientFromDB(userID)

--- a/wmiau.go
+++ b/wmiau.go
@@ -501,7 +501,7 @@ func (s *server) startClient(userID string, textjid string, token string, kill c
 			}
 
 			if webhookUseProxy {
-				applyRestyProxy(webhookClient, proxyURL)
+				webhookClient.SetProxy(proxyURL)
 				log.Info().Msg("Proxy configured for webhook delivery client")
 			} else {
 				log.Info().Msg("Webhook delivery client bypassing proxy")

--- a/wmiau.go
+++ b/wmiau.go
@@ -453,8 +453,7 @@ func (s *server) startClient(userID string, textjid string, token string, kill c
 	// Store the MyClient in clientManager
 	clientManager.SetMyClient(userID, &mycli)
 
-	// Webhook client: intentionally created without a proxy so webhook deliveries
-	// bypass any WhatsApp proxy configured for the websocket connection.
+	// Webhook HTTP client for outgoing webhook deliveries.
 	webhookClient := resty.New()
 	webhookClient.SetRedirectPolicy(resty.FlexibleRedirectPolicy(15))
 	if *waDebug == "DEBUG" {
@@ -471,17 +470,18 @@ func (s *server) startClient(userID string, textjid string, token string, kill c
 		}
 	})
 
-	// Set proxy for the WhatsApp connection if defined in DB (assumes users table contains proxy_url column).
-	// The webhook client above is deliberately left without a proxy.
 	var proxyURL string
-	err = s.db.Get(&proxyURL, "SELECT proxy_url FROM users WHERE id=$1", userID)
+	var webhookUseProxy bool
+	err = s.db.QueryRow(
+		"SELECT proxy_url, COALESCE(webhook_use_proxy, true) FROM users WHERE id=$1",
+		userID,
+	).Scan(&proxyURL, &webhookUseProxy)
 	if err == nil && proxyURL != "" {
 		parsed, perr := url.Parse(proxyURL)
 		if perr != nil {
 			log.Warn().Err(perr).Str("proxy", proxyURL).Msg("Invalid proxy URL, skipping proxy setup")
 		} else {
-
-			log.Info().Str("proxy", proxyURL).Msg("Configuring proxy")
+			log.Info().Str("proxy", proxyURL).Bool("webhook_use_proxy", webhookUseProxy).Msg("Configuring proxy")
 
 			if parsed.Scheme == "socks5" || parsed.Scheme == "socks5h" {
 				dialer, derr := proxy.FromURL(parsed, nil)
@@ -494,6 +494,13 @@ func (s *server) startClient(userID string, textjid string, token string, kill c
 			} else {
 				client.SetProxyAddress(parsed.String(), whatsmeow.SetProxyOptions{})
 				log.Info().Msg("HTTP/HTTPS proxy configured for WhatsApp connection")
+			}
+
+			if webhookUseProxy {
+				applyRestyProxy(webhookClient, proxyURL)
+				log.Info().Msg("Proxy configured for webhook delivery client")
+			} else {
+				log.Info().Msg("Webhook delivery client bypassing proxy")
 			}
 		}
 	}


### PR DESCRIPTION
Closes #338

## Summary

Since PR #152, when a per-user proxy is configured, the same proxy is applied to both the WhatsApp websocket client and the internal Resty HTTP client used for outgoing webhook deliveries. In some deployments the proxy is a dedicated exit for WhatsApp traffic, while webhooks need to reach the application backend directly.

This PR adds a configurable option so webhook delivery can bypass the configured proxy while the WhatsApp connection still uses it.

## Behavior

- **Backward-compatible default**: `webhook_use_proxy = true` — webhooks continue to use the proxy when one is configured
- **When set to `false`**: the per-user webhook `resty.Client` does not call `SetProxy(...)`, while `client.SetProxyAddress` / `client.SetSOCKSProxy` for the WhatsApp connection remain unchanged

## Configuration

| Scope | Setting | Default |
|-------|---------|---------|
| Global | `WUZAPI_WEBHOOK_USE_PROXY=true\|false` | `true` |
| Per-user (admin API) | `proxyConfig.webhookUseProxy` | global default |
| Per-user (session API) | `webhook_use_proxy` in `POST /session/proxy` | global default |

## Changes

- DB migration: `webhook_use_proxy BOOLEAN DEFAULT TRUE` on `users`
- `startClient`: conditionally applies proxy to webhook client based on per-user setting
- Admin/session API handlers and dashboard UI toggle
- Tests for `resolveWebhookUseProxy`

## Related

- Issue #338 — feature request this PR implements
- PR #152 — introduced per-user proxy support
- Issue #314 — related discussion about webhook HTTP client setup

## Test plan

- [x] `go test ./...`
- [x] Verified locally with `docker compose up --build`
- [x] Confirmed WhatsApp connection still uses proxy when configured
- [x] Confirmed webhook client bypasses proxy when `webhook_use_proxy=false`