### PR TITLE
Add /user/presence/subscribe and forward last_seen in Presence webhook

### DIFF
--- a/API.md
+++ b/API.md
@@ -1007,6 +1007,37 @@ curl -X POST -H 'Token: 1234ABCD' -H 'Content-Type: application/json' --data '{"
 
 ---
 
+## Subscribe to Contact Presence
+
+Subscribes to a contact's presence updates (online/offline and last seen). After
+subscribing, your configured webhook receives `Presence` events for that contact. You
+should be online yourself to receive presence (wuzapi sends an available presence on
+connect). Whether `last_seen` is available depends on the contact's privacy settings.
+
+endpoint: _/user/presence/subscribe_
+
+method: **POST**
+
+```
+curl -X POST -H 'Token: 1234ABCD' -H 'Content-Type: application/json' --data '{"Phone":"5491155554444"}' http://localhost:8080/user/presence/subscribe
+```
+
+The resulting webhook `Presence` event looks like:
+
+```json
+{
+  "type": "Presence",
+  "state": "offline",
+  "from": "5491155554444@s.whatsapp.net",
+  "last_seen": 1750000000
+}
+```
+
+`last_seen` is a Unix timestamp, present only when the contact is offline and shares
+their last seen. When the contact is online, only `type`, `from` and `state` are sent.
+
+---
+
 ## Mark message(s) as read
 
 Indicates that one or more messages were read. Id is an array of messages Ids.

--- a/handlers.go
+++ b/handlers.go
@@ -3479,7 +3479,7 @@ func (s *server) SubscribePresence() http.HandlerFunc {
 
 		log.Info().Str("jid", jid.String()).Msg("Subscribed to presence")
 
-		response := map[string]interface{}{"Details": "Presence subscription requested successfuly"}
+		response := map[string]interface{}{"Details": "Presence subscription requested successfully"}
 		responseJson, err := json.Marshal(response)
 		if err != nil {
 			s.Respond(w, r, http.StatusInternalServerError, err)

--- a/handlers.go
+++ b/handlers.go
@@ -3471,7 +3471,7 @@ func (s *server) SubscribePresence() http.HandlerFunc {
 			return
 		}
 
-		err = clientManager.GetWhatsmeowClient(txtid).SubscribePresence(context.Background(), jid)
+		err = clientManager.GetWhatsmeowClient(txtid).SubscribePresence(r.Context(), jid)
 		if err != nil {
 			s.Respond(w, r, http.StatusInternalServerError, errors.New("failure subscribing to presence"))
 			return

--- a/handlers.go
+++ b/handlers.go
@@ -3433,6 +3433,64 @@ func (s *server) SendPresence() http.HandlerFunc {
 	}
 }
 
+// Subscribes to a contact's presence (online/offline + last seen).
+// After subscribing, the configured webhook receives "Presence" events for that
+// contact (with state and, when offline, a last_seen unix timestamp). Requires the
+// session to be available/online (wuzapi sends available presence on connect).
+func (s *server) SubscribePresence() http.HandlerFunc {
+
+	type subscribePresenceStruct struct {
+		Phone string
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+
+		txtid := r.Context().Value("userinfo").(Values).Get("Id")
+
+		if clientManager.GetWhatsmeowClient(txtid) == nil {
+			s.Respond(w, r, http.StatusInternalServerError, errors.New("no session"))
+			return
+		}
+
+		decoder := json.NewDecoder(r.Body)
+		var t subscribePresenceStruct
+		err := decoder.Decode(&t)
+		if err != nil {
+			s.Respond(w, r, http.StatusBadRequest, errors.New("could not decode Payload"))
+			return
+		}
+
+		if len(t.Phone) < 1 {
+			s.Respond(w, r, http.StatusBadRequest, errors.New("missing Phone in Payload"))
+			return
+		}
+
+		jid, ok := parseJID(t.Phone)
+		if !ok {
+			s.Respond(w, r, http.StatusBadRequest, errors.New("could not parse Phone"))
+			return
+		}
+
+		err = clientManager.GetWhatsmeowClient(txtid).SubscribePresence(context.Background(), jid)
+		if err != nil {
+			s.Respond(w, r, http.StatusInternalServerError, errors.New("failure subscribing to presence"))
+			return
+		}
+
+		log.Info().Str("jid", jid.String()).Msg("Subscribed to presence")
+
+		response := map[string]interface{}{"Details": "Presence subscription requested successfuly"}
+		responseJson, err := json.Marshal(response)
+		if err != nil {
+			s.Respond(w, r, http.StatusInternalServerError, err)
+		} else {
+			s.Respond(w, r, http.StatusOK, string(responseJson))
+		}
+		return
+
+	}
+}
+
 // Gets avatar info for user
 func (s *server) GetAvatar() http.HandlerFunc {
 

--- a/routes.go
+++ b/routes.go
@@ -127,6 +127,7 @@ func (s *server) routes() {
 	s.router.Handle("/call/reject", c.Then(s.RejectCall())).Methods("POST")
 
 	s.router.Handle("/user/presence", c.Then(s.SendPresence())).Methods("POST")
+	s.router.Handle("/user/presence/subscribe", c.Then(s.SubscribePresence())).Methods("POST")
 	s.router.Handle("/user/info", c.Then(s.GetUser())).Methods("POST")
 	s.router.Handle("/user/check", c.Then(s.CheckUser())).Methods("POST")
 	s.router.Handle("/user/avatar", c.Then(s.GetAvatar())).Methods("POST")

--- a/wmiau.go
+++ b/wmiau.go
@@ -1146,11 +1146,13 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 	case *events.Presence:
 		postmap["type"] = "Presence"
 		dowebhook = 1
+		postmap["from"] = evt.From.String()
 		if evt.Unavailable {
 			postmap["state"] = "offline"
 			if evt.LastSeen.IsZero() {
 				log.Info().Str("from", evt.From.String()).Msg("User is now offline")
 			} else {
+				postmap["last_seen"] = evt.LastSeen.Unix()
 				log.Info().Str("from", evt.From.String()).Str("lastSeen", fmt.Sprintf("%v", evt.LastSeen)).Msg("User is now offline")
 			}
 		} else {


### PR DESCRIPTION
## What

- Add `POST /user/presence/subscribe` which calls whatsmeow's `SubscribePresence(jid)`. whatsmeow only emits `*events.Presence` for a contact **after** you subscribe, so without this there is no way to start receiving a contact's presence.
- Forward `from` and (when offline) a `last_seen` unix timestamp in the `Presence` webhook payload. The event already carries `evt.LastSeen`, but only `state` (online/offline) was sent to the webhook — the timestamp was logged and dropped.
- Document both in `API.md`.

## Why

You can already set your own presence (`/user/presence`) and you receive a `Presence` webhook with `state`, but there is no way to (a) subscribe to a specific contact's presence, nor (b) get their last-seen time. These two small additions make "last seen / online status" usable by API consumers.

## Notes

- Backwards compatible: the `Presence` webhook only gains additional keys (`from`, `last_seen`); existing consumers are unaffected.
- `last_seen` is present only when the contact is offline and shares their last seen (privacy dependent).
- Reciprocity: you must be online to receive presence; wuzapi already sends an available presence on connect.
- Builds clean (`go build ./...`, `go vet ./...`).