### PR TITLE
fix(preview): send User-Agent on OG fetch and upload HQ thumbnail for large preview card

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -2650,25 +2650,40 @@ func (s *server) SendMessage() http.HandlerFunc {
 			msgid = t.Id
 		}
 		var (
-			url         string
-			title       string
-			description string
-			imageData   []byte
+			url string
+			og  openGraphResult
 		)
 		if t.LinkPreview {
 			url = extractFirstURL(t.Body)
 			if url != "" {
-				title, description, imageData = getOpenGraphData(r.Context(), url, txtid)
+				og = getOpenGraphData(r.Context(), url, txtid)
 			}
 		}
 		msg := &waE2E.Message{
 			ExtendedTextMessage: &waE2E.ExtendedTextMessage{
 				Text:          proto.String(t.Body),
 				MatchedText:   proto.String(url),
-				Title:         proto.String(title),
-				Description:   proto.String(description),
-				JPEGThumbnail: imageData,
+				Title:         proto.String(og.Title),
+				Description:   proto.String(og.Description),
+				JPEGThumbnail: og.ImageData,
 			},
+		}
+		// Upload the high-res thumbnail so clients render the large preview
+		// card; without these fields only the small inline thumbnail shows.
+		if len(og.HQImageData) > 0 {
+			uploaded, upErr := clientManager.GetWhatsmeowClient(txtid).Upload(context.Background(), og.HQImageData, whatsmeow.MediaLinkThumbnail)
+			if upErr != nil {
+				log.Warn().Err(upErr).Str("url", url).Msg("Failed to upload link preview thumbnail, sending inline thumbnail only")
+			} else {
+				etm := msg.ExtendedTextMessage
+				etm.ThumbnailDirectPath = proto.String(uploaded.DirectPath)
+				etm.ThumbnailSHA256 = uploaded.FileSHA256
+				etm.ThumbnailEncSHA256 = uploaded.FileEncSHA256
+				etm.MediaKey = uploaded.MediaKey
+				etm.MediaKeyTimestamp = proto.Int64(time.Now().Unix())
+				etm.ThumbnailWidth = proto.Uint32(og.HQWidth)
+				etm.ThumbnailHeight = proto.Uint32(og.HQHeight)
+			}
 		}
 		if t.ContextInfo.StanzaID != nil {
 			var qm *waE2E.Message

--- a/handlers.go
+++ b/handlers.go
@@ -2671,7 +2671,7 @@ func (s *server) SendMessage() http.HandlerFunc {
 		// Upload the high-res thumbnail so clients render the large preview
 		// card; without these fields only the small inline thumbnail shows.
 		if len(og.HQImageData) > 0 {
-			uploaded, upErr := clientManager.GetWhatsmeowClient(txtid).Upload(context.Background(), og.HQImageData, whatsmeow.MediaLinkThumbnail)
+			uploaded, upErr := clientManager.GetWhatsmeowClient(txtid).Upload(r.Context(), og.HQImageData, whatsmeow.MediaLinkThumbnail)
 			if upErr != nil {
 				log.Warn().Err(upErr).Str("url", url).Msg("Failed to upload link preview thumbnail, sending inline thumbnail only")
 			} else {

--- a/helpers.go
+++ b/helpers.go
@@ -805,13 +805,15 @@ func fetchOpenGraphImage(ctx context.Context, pageURL *url.URL, imageURLStr stri
 		return
 	}
 
-	result.ImageData = encodeJPEGThumbnail(resize.Thumbnail(openGraphThumbnailWidth, openGraphThumbnailHeight, img, resize.Lanczos3))
-
 	hqThumb := resize.Thumbnail(openGraphHQThumbnailDim, openGraphHQThumbnailDim, img, resize.Lanczos3)
 	result.HQImageData = encodeJPEGThumbnail(hqThumb)
 	bounds := hqThumb.Bounds()
 	result.HQWidth = uint32(bounds.Dx())
 	result.HQHeight = uint32(bounds.Dy())
+
+	// Downscale the inline thumbnail from hqThumb (max 600px) instead of
+	// resizing the original image (up to 4000px) a second time.
+	result.ImageData = encodeJPEGThumbnail(resize.Thumbnail(openGraphThumbnailWidth, openGraphThumbnailHeight, hqThumb, resize.Lanczos3))
 }
 
 func runFFmpegConversion(input []byte, inputExt string, ffmpegArgs func(inPath, outPath string) []string, errMsg string) ([]byte, error) {

--- a/helpers.go
+++ b/helpers.go
@@ -765,6 +765,12 @@ func encodeJPEGThumbnail(img image.Image) []byte {
 }
 
 func fetchOpenGraphImage(ctx context.Context, pageURL *url.URL, imageURLStr string, result *openGraphResult) {
+	// No image found on the page; an empty string would resolve to the page
+	// URL itself and we would try to decode HTML as an image.
+	if imageURLStr == "" {
+		return
+	}
+
 	imageURL, err := url.Parse(imageURLStr)
 	if err != nil {
 		log.Warn().Err(err).Str("imageURL", imageURLStr).Msg("Failed to parse Open Graph image URL")

--- a/helpers.go
+++ b/helpers.go
@@ -50,8 +50,9 @@ const (
 	fetchDocumentMaxBytes    = 100 * 1024 * 1024 // 100MB
 	openGraphPageMaxBytes    = 2 * 1024 * 1024   // 2MB
 	openGraphImageMaxBytes   = 10 * 1024 * 1024  // 10MB
-	openGraphThumbnailWidth  = 100
-	openGraphThumbnailHeight = 100
+	openGraphThumbnailWidth  = 192
+	openGraphThumbnailHeight = 192
+	openGraphHQThumbnailDim  = 600 // Max dimension of the uploaded thumbnail used for the large preview card
 	openGraphJpegQuality     = 80
 	openGraphMaxImageDim     = 4000 // Max width or height for Open Graph images
 	openGraphUserFetchLimit  = 20   // Limit concurrent Open Graph fetches per user
@@ -116,7 +117,10 @@ func proxyConfigResponse(proxyURL string, webhookUseProxy bool) map[string]inter
 type openGraphResult struct {
 	Title       string
 	Description string
-	ImageData   []byte
+	ImageData   []byte // small inline thumbnail (JPEGThumbnail field)
+	HQImageData []byte // larger thumbnail uploaded to WA media servers for the big preview card
+	HQWidth     uint32
+	HQHeight    uint32
 }
 
 type UserSemaphoreManager struct {
@@ -170,6 +174,15 @@ func fetchURLBytes(ctx context.Context, resourceURL string, limit int64) ([]byte
 		return nil, "", err
 	}
 
+	// Sites with bot protection (e.g. Mercado Livre) return 403 to Go's
+	// default "Go-http-client" agent; WhatsApp's own preview fetcher UA is
+	// widely allowed since sites want their links previewed in WhatsApp.
+	req.Header.Set("User-Agent", "WhatsApp/2.23.20.0")
+	// Do not advertise image/avif: CDNs then serve AVIF, which Go's image
+	// package cannot decode (gif/png/jpeg/webp decoders are registered).
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8")
+	req.Header.Set("Accept-Language", "pt-BR,pt;q=0.9,en;q=0.8")
+
 	resp, err := globalHTTPClient.Do(req)
 	if err != nil {
 		return nil, "", err
@@ -197,12 +210,12 @@ func fetchURLBytes(ctx context.Context, resourceURL string, limit int64) ([]byte
 	return data, contentType, nil
 }
 
-func getOpenGraphData(ctx context.Context, urlStr string, userID string) (title, description string, imageData []byte) {
+func getOpenGraphData(ctx context.Context, urlStr string, userID string) openGraphResult {
 	// Check cache first
 	if cachedData, found := openGraphCache.Get(urlStr); found {
 		if data, ok := cachedData.(openGraphResult); ok {
 			log.Debug().Str("url", urlStr).Msg("Open Graph data fetched from cache")
-			return data.Title, data.Description, data.ImageData
+			return data
 		}
 	}
 
@@ -234,25 +247,24 @@ func getOpenGraphData(ctx context.Context, urlStr string, userID string) (title,
 		}()
 
 		// Fetch Open Graph data
-		title, description, imageData := fetchOpenGraphData(ctx, urlStr)
+		result := fetchOpenGraphData(ctx, urlStr)
 
 		// Store in cache
-		openGraphCache.Set(urlStr, openGraphResult{title, description, imageData}, cache.DefaultExpiration)
+		openGraphCache.Set(urlStr, result, cache.DefaultExpiration)
 
-		return openGraphResult{title, description, imageData}, nil
+		return result, nil
 	})
 
 	if err != nil {
 		log.Error().Err(err).Str("url", urlStr).Msg("Error fetching Open Graph data via singleflight")
-		return "", "", nil
+		return openGraphResult{}
 	}
 
 	if v == nil {
-		return "", "", nil
+		return openGraphResult{}
 	}
 
-	data := v.(openGraphResult)
-	return data.Title, data.Description, data.ImageData
+	return v.(openGraphResult)
 }
 
 // Update entry in User map
@@ -690,17 +702,17 @@ func extractFirstURL(text string) string {
 
 	return match
 }
-func fetchOpenGraphData(ctx context.Context, urlStr string) (string, string, []byte) {
+func fetchOpenGraphData(ctx context.Context, urlStr string) openGraphResult {
 	pageData, _, err := fetchURLBytes(ctx, urlStr, openGraphPageMaxBytes)
 	if err != nil {
 		log.Warn().Err(err).Str("url", urlStr).Msg("Failed to fetch URL for Open Graph data")
-		return "", "", nil
+		return openGraphResult{}
 	}
 
 	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(pageData))
 	if err != nil {
 		log.Warn().Err(err).Str("url", urlStr).Msg("Failed to parse HTML for Open Graph data")
-		return "", "", nil
+		return openGraphResult{}
 	}
 
 	title := doc.Find(`meta[property="og:title"]`).AttrOr("content", "")
@@ -731,34 +743,45 @@ func fetchOpenGraphData(ctx context.Context, urlStr string) (string, string, []b
 		}
 	}
 
+	result := openGraphResult{Title: title, Description: description}
+
 	pageURL, err := url.Parse(urlStr)
 	if err != nil {
 		log.Warn().Err(err).Str("url", urlStr).Msg("Failed to parse page URL for resolving image URL")
-		return title, description, nil
+		return result
 	}
 
-	imageData := fetchOpenGraphImage(ctx, pageURL, imageURLStr)
-	return title, description, imageData
+	fetchOpenGraphImage(ctx, pageURL, imageURLStr, &result)
+	return result
 }
 
-func fetchOpenGraphImage(ctx context.Context, pageURL *url.URL, imageURLStr string) []byte {
+func encodeJPEGThumbnail(img image.Image) []byte {
+	var buf bytes.Buffer
+	if err := jpeg.Encode(&buf, img, &jpeg.Options{Quality: openGraphJpegQuality}); err != nil {
+		log.Warn().Err(err).Msg("Failed to encode thumbnail to JPEG")
+		return nil
+	}
+	return buf.Bytes()
+}
+
+func fetchOpenGraphImage(ctx context.Context, pageURL *url.URL, imageURLStr string, result *openGraphResult) {
 	imageURL, err := url.Parse(imageURLStr)
 	if err != nil {
 		log.Warn().Err(err).Str("imageURL", imageURLStr).Msg("Failed to parse Open Graph image URL")
-		return nil
+		return
 	}
 
 	resolvedImageURL := pageURL.ResolveReference(imageURL).String()
 	imgBytes, _, err := fetchURLBytes(ctx, resolvedImageURL, openGraphImageMaxBytes)
 	if err != nil {
 		log.Warn().Err(err).Str("imageURL", resolvedImageURL).Msg("Failed to fetch Open Graph image")
-		return nil
+		return
 	}
 
 	imgConfig, _, err := image.DecodeConfig(bytes.NewReader(imgBytes))
 	if err != nil {
 		log.Warn().Err(err).Str("imageURL", resolvedImageURL).Msg("Failed to decode Open Graph image config")
-		return nil
+		return
 	}
 
 	if imgConfig.Width > openGraphMaxImageDim || imgConfig.Height > openGraphMaxImageDim {
@@ -767,23 +790,22 @@ func fetchOpenGraphImage(ctx context.Context, pageURL *url.URL, imageURLStr stri
 			Int("height", imgConfig.Height).
 			Str("imageURL", resolvedImageURL).
 			Msg("Open Graph image dimensions too large")
-		return nil
+		return
 	}
 
 	img, _, err := image.Decode(bytes.NewReader(imgBytes))
 	if err != nil {
 		log.Warn().Err(err).Str("imageURL", resolvedImageURL).Msg("Failed to decode Open Graph image")
-		return nil
+		return
 	}
 
-	thumbnail := resize.Thumbnail(openGraphThumbnailWidth, openGraphThumbnailHeight, img, resize.Lanczos3)
-	var buf bytes.Buffer
-	if err := jpeg.Encode(&buf, thumbnail, &jpeg.Options{Quality: openGraphJpegQuality}); err != nil {
-		log.Warn().Err(err).Msg("Failed to encode thumbnail to JPEG")
-		return nil
-	}
+	result.ImageData = encodeJPEGThumbnail(resize.Thumbnail(openGraphThumbnailWidth, openGraphThumbnailHeight, img, resize.Lanczos3))
 
-	return buf.Bytes()
+	hqThumb := resize.Thumbnail(openGraphHQThumbnailDim, openGraphHQThumbnailDim, img, resize.Lanczos3)
+	result.HQImageData = encodeJPEGThumbnail(hqThumb)
+	bounds := hqThumb.Bounds()
+	result.HQWidth = uint32(bounds.Dx())
+	result.HQHeight = uint32(bounds.Dy())
 }
 
 func runFFmpegConversion(input []byte, inputExt string, ffmpegArgs func(inPath, outPath string) []string, errMsg string) ([]byte, error) {


### PR DESCRIPTION
## Summary

Link previews (`"LinkPreview": true` on `POST /chat/send/text`) had three problems, all fixed here:

1. **Bot-protected sites returned 403 and the preview silently came out empty.** Open Graph requests were sent without a `User-Agent`, so Go's default `Go-http-client/2.0` was used and sites like Mercado Livre, Shopee and Amazon short links refused the request. Requests now send `User-Agent: WhatsApp/2.23.20.0` (the UA WhatsApp's own preview fetcher uses, which sites allow since they want their links previewed) plus `Accept`/`Accept-Language`. The `Accept` header intentionally does **not** advertise `image/avif`: CDNs (e.g. `ae01.alicdn.com`) would then serve AVIF, which Go's `image` package cannot decode.

2. **Only the small compact preview card was ever rendered.** The code embedded a single 100px inline `JPEGThumbnail`. Official clients render the large preview card (full-width image on top) only when the message references a high-resolution thumbnail uploaded to WhatsApp's media servers. Now a thumbnail of up to 600px is also generated, uploaded via `Client.Upload(..., whatsmeow.MediaLinkThumbnail)`, and referenced through `ThumbnailDirectPath`, `ThumbnailSHA256`, `ThumbnailEncSHA256`, `MediaKey`, `ThumbnailWidth` and `ThumbnailHeight`. If the upload fails, the message falls back to the inline thumbnail instead of failing the send.

3. **WhatsApp Web rendered the large card blurry.** `MediaKeyTimestamp` is required by WhatsApp Web to download the hosted thumbnail; without it, Web falls back to stretching the tiny inline thumbnail. It is now set, and the inline thumbnail size was raised from 100px to 192px, which is the size official clients embed (verified against real messages received from official clients).

`getOpenGraphData` now returns the `openGraphResult` struct instead of three separate values, so the handler can access both thumbnails and the dimensions.

## Evidence

Before the fix, sending a Mercado Livre product link with `"LinkPreview": true` logged:

```
{"level":"warn","error":"unexpected status code 403","url":"https://produto.mercadolivre.com.br/MLB-4810647054-...","message":"Failed to fetch URL for Open Graph data"}
```

and the message was delivered with no preview card at all.

User-Agent check against the same URL:

| Request | Result |
|---|---|
| no User-Agent (Go default) | **403 Forbidden** |
| `User-Agent: WhatsApp/2.23.20.0` | 200 OK |
| `User-Agent: facebookexternalhit/1.1 ...` | 200 OK |

AVIF check against the AliExpress CDN (`ae01.alicdn.com/kf/....jpg`):

| `Accept` header | Served content |
|---|---|
| `...,image/avif,image/webp,*/*;q=0.8` | `image/avif` → `image: unknown format`, thumbnail dropped |
| `...,image/webp,*/*;q=0.8` (this PR) | `image/webp` → decoded fine (webp decoder is already imported) |

After the fix, all of the following were sent through the API and verified on Android and WhatsApp Web:

- `https://github.com` — large sharp card (site without bot protection, regression check)
- `https://produto.mercadolivre.com.br/MLB-4810647054-...` — large sharp card (previously: no preview at all)
- `https://meli.la/1ER8rwq` — short link, redirect followed with the UA preserved, large sharp card
- `https://s.shopee.com.br/9fJAInl3U4` — large sharp card
- `https://amzn.to/4pvvoqJ` — large sharp card
- `https://s.click.aliexpress.com/e/_c4Oa6MOX` — large sharp card (previously: card without image due to AVIF)
- Message containing three links — preview generated for the first URL, matching official client behavior

Before setting `MediaKeyTimestamp`, the large card rendered correctly on the phone but blurry on WhatsApp Web; with it set, both render sharp. No errors or warnings in the server logs for any of the sends above.

<img width="1091" height="928" alt="image" src="https://github.com/user-attachments/assets/36634c73-360f-4df7-b930-71fde68214c0" />

