### PR TITLE
Only log full webhook payload when small

### DIFF
--- a/wmiau.go
+++ b/wmiau.go
@@ -183,7 +183,15 @@ func sendToUserWebHookWithHmac(webhookurl string, path string, jsonData []byte, 
 		"instanceName": instance_name,
 	}
 
-	log.Debug().Interface("webhookData", data).Msg("Data being sent to webhook")
+	if len(jsonData) > 8192 {
+		log.Debug().
+			Str("userID", userID).
+			Str("instanceName", instance_name).
+			Int("jsonDataBytes", len(jsonData)).
+			Msg("Data being sent to webhook")
+	} else {
+		log.Debug().Interface("webhookData", data).Msg("Data being sent to webhook")
+	}
 
 	if webhookurl != "" {
 		log.Info().Str("url", webhookurl).Msg("Calling user webhook")


### PR DESCRIPTION
Webhook debug logging previously wrote the full event payload on every send. For image messages with base64 data this can be tens of MB, producing oversized log lines and unbounded disk growth on resource-constrained hosts. Now the full payload is logged only when under 8KB; larger payloads log metadata (user, instance, byte size) instead.