### PR TITLE
feat: rate limit per peer to mitigate decrypt burst

### DIFF
--- a/ratelimit.go
+++ b/ratelimit.go
@@ -1,0 +1,112 @@
+// ratelimit.go - Rate limit por peer (sender) para prevenir decrypt burst
+//
+// Contexto: quando WhatsApp faz sender key rotation em grupos ativos, msgs podem
+// chegar em burst com iterations muito à frente. libsignal-go fará ratchet
+// forward de até 2000 steps por msg (groups/GroupCipher.go:getSenderKey). Se
+// 100+ msgs chegam próximas do mesmo peer, CPU/mem satura, decrypt trunca
+// payloads longos.
+//
+// Fix: token bucket por peer. Se peer excede N msgs em janela T, dropar
+// excedente. Msgs legítimas de conversação (< 5 msgs/segundo) passam livres.
+// Bombardeio de rotação (>50 msgs/segundo) é achatado.
+//
+// Config via env:
+//   RATE_LIMIT_PEER_MSG_PER_SEC=20   (default; ajuste conforme uso)
+//   RATE_LIMIT_PEER_ENABLED=true     (default; setar false pra desligar)
+
+package main
+
+import (
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+type peerBucket struct {
+	tokens     float64
+	lastRefill time.Time
+	mu         sync.Mutex
+}
+
+type peerRateLimiter struct {
+	buckets  sync.Map // key = peer JID string, value = *peerBucket
+	rate     float64  // tokens per second
+	capacity float64  // max tokens
+	enabled  bool
+}
+
+var globalPeerLimiter *peerRateLimiter
+var globalPeerLimiterOnce sync.Once
+
+func getPeerLimiter() *peerRateLimiter {
+	globalPeerLimiterOnce.Do(func() {
+		rate := parseEnvFloat("RATE_LIMIT_PEER_MSG_PER_SEC", 20.0)
+		enabled := parseEnvBool("RATE_LIMIT_PEER_ENABLED", true)
+		globalPeerLimiter = &peerRateLimiter{
+			rate:     rate,
+			capacity: rate * 2, // burst tolerance = 2s
+			enabled:  enabled,
+		}
+		log.Info().
+			Float64("rate_per_sec", rate).
+			Float64("capacity", rate*2).
+			Bool("enabled", enabled).
+			Msg("[PEER_RATE_LIMIT] initialized")
+	})
+	return globalPeerLimiter
+}
+
+// Allow returns true if peer msg should be processed, false if dropped.
+func (p *peerRateLimiter) Allow(peerKey string) bool {
+	if !p.enabled {
+		return true
+	}
+	now := time.Now()
+	bucketI, _ := p.buckets.LoadOrStore(peerKey, &peerBucket{
+		tokens:     p.capacity,
+		lastRefill: now,
+	})
+	b := bucketI.(*peerBucket)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	elapsed := now.Sub(b.lastRefill).Seconds()
+	b.tokens += elapsed * p.rate
+	if b.tokens > p.capacity {
+		b.tokens = p.capacity
+	}
+	b.lastRefill = now
+
+	if b.tokens < 1 {
+		return false
+	}
+	b.tokens--
+	return true
+}
+
+func parseEnvFloat(key string, def float64) float64 {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return def
+	}
+	return f
+}
+
+func parseEnvBool(key string, def bool) bool {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return def
+	}
+	return b
+}

--- a/wmiau.go
+++ b/wmiau.go
@@ -962,6 +962,22 @@ func (mycli *MyClient) myEventHandler(rawEvt interface{}) {
 		return
 	case *events.Message:
 
+		// [PEER_RATE_LIMIT] descarta msgs em burst do mesmo peer (fix decrypt burst)
+		{
+			peerKey := evt.Info.Sender.String()
+			if evt.Info.IsGroup {
+				peerKey = evt.Info.Chat.String() + "|" + peerKey
+			}
+			if !getPeerLimiter().Allow(peerKey) {
+				log.Warn().
+					Str("peer", peerKey).
+					Str("msg_id", evt.Info.ID).
+					Bool("is_group", evt.Info.IsGroup).
+					Msg("[PEER_RATE_LIMIT] msg dropped (peer excedeu rate)")
+				return
+			}
+		}
+
 		var s3Config struct {
 			Enabled       string `db:"s3_enabled"`
 			MediaDelivery string `db:"media_delivery"`


### PR DESCRIPTION
## Problem

On active WhatsApp groups, sender key rotation causes messages to arrive with encryption iterations far ahead of the current sender chain. The libsignal-go library `groups/GroupCipher.go:getSenderKey` ratchets forward up to 2000 steps per message to catch up.

When many messages from the same peer arrive concurrently, this can result in ~200k crypto operations in seconds. CPU/memory saturate and long message payloads get truncated during decrypt — we've observed real user reports of messages arriving with truncated bodies (only the URL kept, description dropped).

Root symptom in production: p50 latency wa→db of 14s, p90 of 850s, max of 3000s during burst events. Recovery only via container restart.

## Solution

Per-peer token bucket rate limiter as a defensive layer at the wuzapi wrapper level. No changes to libsignal or whatsmeow.

## Changes

- `ratelimit.go` new: token bucket, `sync.Once` lazy init, configured via env
- `wmiau.go`: guard at the top of `case *events.Message`

## Configuration

| Env | Default | Meaning |
|---|---|---|
| `RATE_LIMIT_PEER_MSG_PER_SEC` | 20 | sustained rate per peer |
| `RATE_LIMIT_PEER_ENABLED` | true | set false to disable feature |

Capacity = rate × 2 burst tolerance 2s. Peer key = Sender JID or Chat|Sender for groups.

## Behavior

- Peers within limit: unaffected default 20/s handles all normal traffic
- Peer that exceeds: excess msgs dropped silently, warn log emitted with `msg_id` and `peer` for observability
- Legitimate conversation less than 5 msgs/sec always passes
- Bombardment during sender key rotation more than 50 msgs/sec is flattened

## Not a root cause fix

The underlying issue is in libsignal-go — `getSenderKey` lacks a cost bound. A proper fix would add a per-sender rate limit in the crypto layer itself. That path requires forking libsignal, whatsmeow, and wuzapi.

This PR chooses the minimally invasive path: single fork, non-crypto code, easily reversible via env flag. Happy to abandon this if a crypto-layer fix lands upstream in libsignal-go.

## Test plan

- Fork built and deployed alongside main wuzapi port 8091 on our staging setup
- Container running SQLite backend, isolated from prod
- Idle stability observed OK — ready for canary QR pairing to measure real-world impact vs baseline

Open as draft while we validate in canary mode.
