### PR TITLE
fix(migrations): create days_to_sync_history column read by wmiau.go

### DIFF
--- a/migrations.go
+++ b/migrations.go
@@ -86,6 +86,15 @@ var migrations = []Migration{
 		Name:  "repair_webhook_use_proxy",
 		UpSQL: repairWebhookUseProxySQL,
 	},
+	{
+		// wmiau.go reads days_to_sync_history when deciding how much history
+		// to request on connect, but no migration ever creates the column, so
+		// on a fresh install the query fails and the feature silently never
+		// runs (it only logs a warning and falls through to 0).
+		ID:    13,
+		Name:  "add_days_to_sync_history",
+		UpSQL: addDaysToSyncHistorySQL,
+	},
 }
 
 const changeIDToStringSQL = `
@@ -253,6 +262,17 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS webhook_use_proxy BOOLEAN DEFAULT TRU
 // that already recorded a different migration 10 or 11 are repaired.
 const repairWebhookUseProxySQL = `
 ALTER TABLE users ADD COLUMN IF NOT EXISTS webhook_use_proxy BOOLEAN DEFAULT TRUE;
+`
+
+const addDaysToSyncHistorySQL = `
+-- PostgreSQL version
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'days_to_sync_history') THEN
+        ALTER TABLE users ADD COLUMN days_to_sync_history INTEGER DEFAULT 0;
+    END IF;
+END $$;
+-- SQLite version (handled in code)
 `
 
 // GenerateRandomID creates a random string ID
@@ -519,6 +539,12 @@ func applyMigration(db *sqlx.DB, migration Migration) error {
 	} else if migration.ID == 9 {
 		if db.DriverName() == "sqlite" {
 			err = nil
+		} else {
+			_, err = tx.Exec(migration.UpSQL)
+		}
+	} else if migration.ID == 13 {
+		if db.DriverName() == "sqlite" {
+			err = addColumnIfNotExistsSQLite(tx, "users", "days_to_sync_history", "INTEGER DEFAULT 0")
 		} else {
 			_, err = tx.Exec(migration.UpSQL)
 		}


### PR DESCRIPTION
## Problem

`wmiau.go` reads `days_to_sync_history` when deciding how much history to request on connect:

```go
// wmiau.go:1010
query := "SELECT COALESCE(days_to_sync_history, 0) FROM users WHERE id=$1"
```

But no migration creates that column.

On a fresh install the query errors out, the code logs `Failed to get days_to_sync_history from database` and falls through to `0`, so the history-sync-by-days feature silently never runs. It only works on databases where the column arrived from somewhere else (a hand-written ALTER, or a fork that added its own migration).

Because the failure path only warns and continues, this is easy to miss — there is no error, just a feature that quietly does nothing.

## Fix

Adds migration `13` — the next free ID, since 9, 10 and 12 are taken — creating the column with the same guarded pattern the surrounding migrations already use:

- **PostgreSQL**: `DO $$ ... IF NOT EXISTS (SELECT 1 FROM information_schema.columns ...)`
- **SQLite**: `addColumnIfNotExistsSQLite(tx, "users", "days_to_sync_history", "INTEGER DEFAULT 0")`

Both are no-ops where the column already exists, so this is safe to apply to existing databases.

## Testing

Reviewed against the existing migration idioms in `migrations.go`; the SQLite path reuses the same helper as migrations 10 and 12. I don't have a Go toolchain on this machine to run the suite — worth a CI run before merging.