### PR TITLE
fix(rabbitmq): serialize access to the shared AMQP channel

### DIFF
--- a/rabbitmq.go
+++ b/rabbitmq.go
@@ -16,12 +16,43 @@ var (
 	rabbitEnabled bool
 	rabbitOnce    sync.Once
 	rabbitQueue   string
+
+	// rabbitMu guards rabbitConn/rabbitChannel/rabbitEnabled and serializes every
+	// use of the shared channel. An amqp091.Channel must not be used from several
+	// goroutines at once: Channel.Publish holds the channel's internal mutex while
+	// it writes the method + header + body frames, but Channel.QueueDeclare does
+	// not take that mutex at all. Events are published concurrently (one goroutine
+	// per client event, plus the send-message handler) and every publish declares
+	// the queue first, so a Queue.Declare frame can be written in the middle of
+	// another goroutine's content frames. The broker then closes the whole
+	// connection with "unexpected_frame: expected content body, got non content
+	// body frame instead" and every event still in flight is lost.
+	rabbitMu sync.Mutex
 )
 
 const (
 	maxRetries    = 10
 	retryInterval = 3 * time.Second
 )
+
+// setRabbitConnection publishes the RabbitMQ state under rabbitMu. Publishers
+// read this state while the reconnection goroutine replaces it, so the swap must
+// be atomic with respect to them: without the lock a publisher can observe
+// rabbitEnabled==true together with the channel of an already dead connection.
+func setRabbitConnection(conn *amqp091.Connection, channel *amqp091.Channel, enabled bool) {
+	rabbitMu.Lock()
+	defer rabbitMu.Unlock()
+	rabbitConn = conn
+	rabbitChannel = channel
+	rabbitEnabled = enabled
+}
+
+// rabbitIsEnabled reports whether publishing is currently possible.
+func rabbitIsEnabled() bool {
+	rabbitMu.Lock()
+	defer rabbitMu.Unlock()
+	return rabbitEnabled
+}
 
 // Call this in main() or initialization
 func InitRabbitMQ() {
@@ -95,9 +126,7 @@ func InitRabbitMQ() {
 		}
 
 		// Success!
-		rabbitConn = conn
-		rabbitChannel = channel
-		rabbitEnabled = true
+		setRabbitConnection(conn, channel, true)
 
 		log.Info().
 			Str("queue", rabbitQueue).
@@ -112,14 +141,19 @@ func InitRabbitMQ() {
 
 // Monitor connection errors and attempt reconnection
 func handleConnectionErrors() {
-	notifyClose := rabbitConn.NotifyClose(make(chan *amqp091.Error))
+	rabbitMu.Lock()
+	currentConn := rabbitConn
+	rabbitMu.Unlock()
+
+	notifyClose := currentConn.NotifyClose(make(chan *amqp091.Error))
 
 	for err := range notifyClose {
 		log.Error().
 			Err(err).
 			Msg("RabbitMQ connection closed unexpectedly. Attempting reconnection...")
 
-		rabbitEnabled = false
+		// Clear the dead connection so no publisher can reach its channel.
+		setRabbitConnection(nil, nil, false)
 
 		// Attempt to reconnect
 		for attempt := 1; attempt <= maxRetries; attempt++ {
@@ -150,9 +184,7 @@ func handleConnectionErrors() {
 			}
 
 			// Reconnection successful
-			rabbitConn = conn
-			rabbitChannel = channel
-			rabbitEnabled = true
+			setRabbitConnection(conn, channel, true)
 
 			log.Info().Msg("RabbitMQ reconnected successfully")
 
@@ -168,15 +200,22 @@ func handleConnectionErrors() {
 
 // Optionally, allow overriding the queue per message
 func PublishToRabbit(data []byte, queueOverride ...string) error {
+	// Both calls below write frames on the same shared AMQP channel and must not
+	// interleave with another goroutine's, so the lock covers declare + publish
+	// as one unit. See rabbitMu.
+	rabbitMu.Lock()
+	defer rabbitMu.Unlock()
+
 	if !rabbitEnabled {
 		return nil
 	}
+	channel := rabbitChannel
 	queueName := rabbitQueue
 	if len(queueOverride) > 0 && queueOverride[0] != "" {
 		queueName = queueOverride[0]
 	}
 	// Declare queue (idempotent)
-	_, err := rabbitChannel.QueueDeclare(
+	_, err := channel.QueueDeclare(
 		queueName,
 		true,  // durable
 		false, // auto-delete
@@ -188,7 +227,7 @@ func PublishToRabbit(data []byte, queueOverride ...string) error {
 		log.Error().Err(err).Str("queue", queueName).Msg("Could not declare RabbitMQ queue")
 		return err
 	}
-	err = rabbitChannel.Publish(
+	err = channel.Publish(
 		"",        // exchange (default)
 		queueName, // routing key = queue
 		false,     // mandatory
@@ -208,7 +247,7 @@ func PublishToRabbit(data []byte, queueOverride ...string) error {
 }
 
 func sendToGlobalRabbit(jsonData []byte, token string, userID string, queueName ...string) {
-	if !rabbitEnabled {
+	if !rabbitIsEnabled() {
 		// Check if RabbitMQ is configured but disabled due to connection issues
 		rabbitURL := os.Getenv("RABBITMQ_URL")
 		rabbitQueueEnv := os.Getenv("RABBITMQ_QUEUE")

--- a/rabbitmq_test.go
+++ b/rabbitmq_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"sync"
+	"testing"
+)
+
+// restoreRabbitState snapshots the package-level RabbitMQ state and restores it
+// when the test ends, so these tests do not leak into any other test.
+func restoreRabbitState(t *testing.T) {
+	t.Helper()
+
+	rabbitMu.Lock()
+	conn, channel, enabled := rabbitConn, rabbitChannel, rabbitEnabled
+	rabbitMu.Unlock()
+
+	t.Cleanup(func() {
+		setRabbitConnection(conn, channel, enabled)
+	})
+}
+
+// TestRabbitStateHelpers covers the accessors that replaced the bare reads and
+// writes of rabbitConn/rabbitChannel/rabbitEnabled.
+func TestRabbitStateHelpers(t *testing.T) {
+	restoreRabbitState(t)
+
+	setRabbitConnection(nil, nil, false)
+	if rabbitIsEnabled() {
+		t.Error("rabbitIsEnabled() = true after disabling, want false")
+	}
+
+	// A disabled publisher is a no-op and must not touch the nil channel.
+	if err := PublishToRabbit([]byte(`{"x":1}`)); err != nil {
+		t.Errorf("PublishToRabbit while disabled returned %v, want nil", err)
+	}
+
+	setRabbitConnection(nil, nil, true)
+	if !rabbitIsEnabled() {
+		t.Error("rabbitIsEnabled() = false after enabling, want true")
+	}
+}
+
+// TestRabbitConnectionSwapConcurrent reproduces the production shape: the broker
+// drops the connection, handleConnectionErrors swaps rabbitConn/rabbitChannel/
+// rabbitEnabled, and meanwhile event goroutines are calling PublishToRabbit.
+//
+// The point is the -race build. Before the fix the swap and the publishers
+// touched those globals with no synchronization at all, and `go test -race`
+// reports a data race here. It stays quiet once every access goes through
+// rabbitMu.
+//
+// Note what this does NOT cover: the frame interleaving on the shared
+// amqp091.Channel itself. That one happens inside the library, across a socket,
+// and the race detector cannot see it — publishing is kept disabled here so the
+// nil channel is never dereferenced.
+func TestRabbitConnectionSwapConcurrent(t *testing.T) {
+	restoreRabbitState(t)
+
+	setRabbitConnection(nil, nil, false)
+
+	const iterations = 500
+	var wg sync.WaitGroup
+
+	// Reconnection goroutine: the disable/enable cycle of handleConnectionErrors.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			setRabbitConnection(nil, nil, false)
+		}
+	}()
+
+	// Publisher goroutines: what safeGo("sendToGlobalRabbit", ...) in wmiau.go and
+	// the `go sendToGlobalRabbit(...)` in handlers.go do on every event.
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				if err := PublishToRabbit([]byte(`{"type":"Message"}`)); err != nil {
+					t.Errorf("PublishToRabbit returned %v, want nil", err)
+					return
+				}
+				_ = rabbitIsEnabled()
+			}
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
Fixes #362.

`PublishToRabbit` uses a single package-level `amqp091.Channel` from several goroutines with no synchronization. `Channel.Publish` holds the channel mutex `ch.m` across its method/header/body frames, but `Channel.QueueDeclare` goes through `ch.call()` and takes no channel mutex — and every publish declares the queue first. A `Queue.Declare` frame can therefore be written between another goroutine's header and body frames, and the broker closes the connection with `unexpected_frame: "expected content body, got non content body frame instead"`. Every event in flight is lost, and `rabbitEnabled` stays `false` afterwards.

## What changes

- `rabbitMu` guards `rabbitConn` / `rabbitChannel` / `rabbitEnabled` and is held across the `QueueDeclare` + `Publish` pair, so one message's frames cannot interleave with another call.
- `setRabbitConnection` / `rabbitIsEnabled` accessors, so the reconnection goroutine and the publishers never observe half-updated state. The dead connection is now cleared on disconnect, instead of only flipping `rabbitEnabled`.
- `rabbitmq_test.go` covering the state races under `go test -race`.

`QueueDeclare` is deliberately left on the publish path. It is what makes a queue deleted at runtime come back; without it, a publish to a missing queue with `mandatory=false` is discarded with no error at all — which would trade a loud failure for a silent one.

## Verification

`go build ./...`, `go vet ./...`, `go test -race ./...`, `gofmt`, `go mod tidy` — all clean.

The test was falsified rather than just written: removing the lock from each of the three functions in turn reproduces a data race and fails the test.

| Lock removed from | Result |
|---|---|
| `setRabbitConnection` | FAIL — 2 data races |
| `rabbitIsEnabled` | FAIL — 1 data race |
| `PublishToRabbit` | FAIL — 1 data race |
| unmutated | PASS |

`-race` covers the shared-state races but not the frame interleaving, which happens on the wire rather than in memory; that part is argued from the library source referenced in #362.

Happy to reshape this if you'd rather declare the queues once at startup, or use one channel per publisher.
